### PR TITLE
feat: automatic steps creation for iOS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,8 @@
     "unicorn/prefer-string-replace-all": "off",
     "unicorn/prevent-abbreviations": "off",
     "unicorn/no-array-callback-reference": "off",
+    "unicorn/no-array-reduce": "off",
+    "unicorn/no-keyword-prefix": "off",
     "unicorn/no-null": "off",
     "unicorn/no-this-assignment": "off",
     "unicorn/no-unused-properties": "off",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 // eslint-disable-next-line import/no-internal-modules
+import detox from 'detox';
+// eslint-disable-next-line import/no-internal-modules
 import { worker } from 'detox/internals';
 // eslint-disable-next-line import/no-internal-modules
 import { allure, type MIMEInferer } from 'jest-allure2-reporter/api';
@@ -9,8 +11,20 @@ import { allure, type MIMEInferer } from 'jest-allure2-reporter/api';
 import type { EnvironmentListenerFn } from 'jest-environment-emit';
 
 import { createLogHandler, createZipHandler } from './file-handlers';
+import { wrapWithSteps } from './steps';
 
-const listener: EnvironmentListenerFn = ({ testEvents }) => {
+export type DetoxAllure2AdapterOptions = {
+  /**
+   * Whether to wrap device, element and other actions in Allure steps
+   * @default false
+   */
+  useSteps?: boolean;
+};
+
+const listener: EnvironmentListenerFn = (
+  { testEvents },
+  { useSteps = false }: DetoxAllure2AdapterOptions = {},
+) => {
   let logHandler: ReturnType<typeof createLogHandler>;
   let zipHandler: ReturnType<typeof createZipHandler>;
   let inferMimeType: MIMEInferer;
@@ -27,6 +41,9 @@ const listener: EnvironmentListenerFn = ({ testEvents }) => {
 
       artifactsManager = (worker as any)._artifactsManager;
       artifactsManager.on('trackArtifact', onTrackArtifact);
+    })
+    .on('setup', async () => {
+      if (useSteps) wrapWithSteps(detox, worker, allure);
     })
     .on('test_start', () => {
       $test = allure.$bind();

--- a/src/preset/allure.ts
+++ b/src/preset/allure.ts
@@ -61,10 +61,6 @@ const options: ReporterOptions = {
       device,
     },
   },
-  testRun: {
-    ignored: ({ aggregatedResult }) =>
-      aggregatedResult.numFailedTests === 0 && aggregatedResult.numFailedTestSuites === 0,
-  },
 };
 
 export default options;

--- a/src/steps/description-maker/index.ts
+++ b/src/steps/description-maker/index.ts
@@ -1,0 +1,1 @@
+export * from './ios';

--- a/src/steps/description-maker/ios/__fixtures__/everything.jsonl
+++ b/src/steps/description-maker/ios/__fixtures__/everything.jsonl
@@ -1,0 +1,491 @@
+{"params":{"testerConnected":true,"appConnected":true},"type":"loginSuccess"}
+{"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/661b57d0-5e61-47ba-934f-ed417e5b1bc7.detox.viewhierarchy"}}
+{"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/7994db2b-a838-488b-8dd6-e1ec0809ac84.detox.viewhierarchy"}}
+{"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/a7d78bd4-ff2d-4652-9347-77d0995835c7.detox.viewhierarchy"}}
+{"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/c4a81636-bd67-4a0f-9f53-4730b6c34311.detox.viewhierarchy"}}
+{"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/cd0aff1f-12ec-4293-b165-98d39121a976.detox.viewhierarchy"}}
+{"type":"cleanup","params":{"stopRunner":false}}
+{"type":"cleanup","params":{"stopRunner":true}}
+{"type":"currentStatus","params":{}}
+{"type":"deliverPayload","params":{"detoxUserActivityDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-jF8YfN/payload.json"}}
+{"type":"deliverPayload","params":{"detoxUserNotificationDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-EtGXXg/payload.json"}}
+{"type":"deliverPayload","params":{"newInstance":false,"detoxUserActivityDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-if4vil/payload.json","delayPayload":true}}
+{"type":"deliverPayload","params":{"newInstance":false,"detoxUserNotificationDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-Nvu0Cj/payload.json","delayPayload":true}}
+{"type":"deliverPayload","params":{"newInstance":false,"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second","delayPayload":true}}
+{"type":"deliverPayload","params":{"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second"}}
+{"type":"generateViewHierarchyXml","params":{"shouldInjectTestIds":false}}
+{"type":"generateViewHierarchyXml","params":{"shouldInjectTestIds":true}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["activate"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["custom"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["decrement"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["escape"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["increment"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["longpress"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["magicTap"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"and","predicates":[{"type":"type","value":"RCTCustomScrollView"},{"type":"ancestor","predicate":{"type":"id","value":"attrScrollView","isRegex":false}}]}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"and","predicates":[{"type":"type","value":"RCTView"},{"type":"ancestor","predicate":{"type":"id","value":"attrScrollView","isRegex":false}}]}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"attrDatePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"blurredTextInputId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"checkboxId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"draggable","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"focusedTextInputId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"sliderId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"textGroupRoot","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"textViewId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"viewId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,0.5,0.5,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,1,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0.5,0.5,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0.5,0.5,0.5,0.5,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,1,0,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,1,0,1,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[null,1500],"predicate":{"type":"text","value":"Long Press Me 1.5s","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[null,null],"predicate":{"type":"text","value":"Tap Me","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[{"x":15,"y":15},null],"predicate":{"type":"text","value":"Long Press on Top Left","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"longPress","params":[{"x":5,"y":5},null],"predicate":{"type":"text","value":"Long Press on Top Left","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"multiTap","params":[3],"predicate":{"type":"id","value":"UniqueId819","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"replaceText","params":["1600"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_delay","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"replaceText","params":["2000"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_duration","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"replaceText","params":["4"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_numberOfIterations","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"replaceText","params":["500"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_delay","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"replaceText","params":["5000"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_duration","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[10,"down",null,null],"predicate":{"type":"id","value":"FSScrollActions.scrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"expectation":"toBeVisible","params":[100]}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[10,"down",null,null],"predicate":{"type":"id","value":"FSScrollActions.scrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"expectation":"toBeVisible","params":[50]}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[100,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[100,"up",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[1000,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[200,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[200,"right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"left",0.2,0.4],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"right",0.8,0.6],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text1000","isRegex":false},"expectation":"toBeVisible"}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"expectation":"toBeVisible"}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Index","isRegex":false},"atIndex":1,"expectation":"toBeVisible"}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[550,"down",0.8,0.6],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scroll","params":[550,"up",0.2,0.4],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",0.2,0.4],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"VerticalScrollView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["left",0.2,0.4],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["left",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["right",0.8,0.6],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["top",0.8,0.6],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"scrollTo","params":["top",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"setColumnToValue","params":[0,"c"],"predicate":{"type":"id","value":"pickerView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"setColumnToValue","params":[1,"6"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2019-02-06T05:10:00-08:00","ISO8601"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2019/02/06 13:10","yyyy/MM/dd HH:mm"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2023-01-11T10:41:26Z","ISO8601"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"swipe","atIndex":0,"params":["down","fast",0.7,null,null],"predicate":{"type":"text","value":"Index","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["elementScreenshot.horiz"],"predicate":{"type":"id","value":"fancyElement","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["elementScreenshot.vert"],"predicate":{"type":"id","value":"fancyElement","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["focus-on-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["focus-on-input-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["move-cursor-to-end-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["move-cursor-to-end-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["scroll-to-view-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["select-all-text-in-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["select-all-text-in-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["tap-on-cross-origin-frame-element"],"predicate":{"type":"id","value":"webView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["type-text-in-cross-origin-frame"],"predicate":{"type":"id","value":"webView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["typing-keep-cursor-position-webview-content-editable-1"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["typing-keep-cursor-position-webview-input-1"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","atIndex":0,"predicate":{"type":"text","value":"Index","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","atIndex":3,"predicate":{"type":"text","value":"Index","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"/UniqueId\\d{3}/","isRegex":true}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"AlertScreen.Button","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"Immediate","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"IntervalIgnore","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"LongNetworkRequest","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"OverlayView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShortNetworkRequest","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowDismissibleAlertButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"SkipOverInterval","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutIgnoreLong","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutIgnoreShort","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutShort","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutZero","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId345","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId819","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_enableLoop","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_startButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"closeButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"get_location_button","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"goButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"keyboardHelloButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"moveHalfVisible","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"nonExistentId","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"requestPermissionButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"switchOrientation","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"textWithCustomInput","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle2ndWebviewButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle3rdWebviewButton","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggleDatePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggleScrollOverlays","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"label","value":"Label","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Actions","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Alerts","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Assertions","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Attributes","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge OneWay Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge TwoWay Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge setState Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Button 1","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Cancel","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 1","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 10","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 11","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 12","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 13","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 14","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 15","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 16","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 17","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 18","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 19","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 2","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 20","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 3","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 4","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 5","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 6","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 7","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 8","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 9","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Crash","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Custom Keyboard","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"DatePicker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Device Tap","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Dismiss","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Drag And Drop","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Element-Screenshots","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"EventLoop Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"FS Scroll Actions","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Init URL","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"JS","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Language","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Location","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Matchers","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Native","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Network","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Next","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Not existing","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"OK","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Orientation","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Overlay","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Permissions","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Picker","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"RN Animations","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Sanity","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Say Hello","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Say World","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Shake","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch Root","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch to a new native root","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch to multiple react roots","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"System Dialogs","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Tap Me","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Timeouts","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"VirtualizedList Stress","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Visibility Debug Artifacts","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Visibility Expectation","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"WaitFor","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"WebView","isRegex":false}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"traits","value":["button"]}}}
+{"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"type","value":"RCTImageView"}}}
+{"type":"invoke","params":{"type":"action","action":"typeText","params":["Type Working 123 אֱבּג абв!!!"],"predicate":{"type":"id","value":"UniqueId937","isRegex":false}}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Father883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Father883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandfather883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandfather883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Father883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandfather883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Son883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Father883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandfather883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Son883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Son883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Son883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"label","value":"RandomJunk","isRegex":false}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"text","value":"ID","isRegex":false}]},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"text","value":"RandomJunk","isRegex":false}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"traits","value":["button"]}]},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["Cancel Pressed"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["Not Pressed"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["OK Pressed"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"LongNetworkRequest","isRegex":false},"expectation":"toBeVisible","timeout":4000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"RandomJunk959","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ScrollView161","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowDismissibleAlertButton","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId819","isRegex":false},"expectation":"toHaveText","params":["Taps: 3"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_enableLoop","isRegex":false},"expectation":"toHaveValue","params":["1"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"expectation":"toExist","timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"modifiers":["not"],"expectation":"toExist","timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"expectation":"toBeFocused","timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"modifiers":["not"],"expectation":"toBeFocused","timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"modifiers":["not"],"expectation":"toBeFocused"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toHaveText","params":["Landscape"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toHaveText","params":["Portrait"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["unavailable"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"expectation":"toBeVisible","params":[25],"timeout":2000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"expectation":"toBeVisible","params":[50]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[26],"timeout":2000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[51]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"localDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (Local): Feb 6th, 2019"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_error","isRegex":false},"expectation":"toBeVisible","timeout":3000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"expectation":"toHaveText","params":["Latitude: -80.125"],"timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"expectation":"toHaveText","params":["Latitude: 66.5"],"timeout":5000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"expectation":"toHaveText","params":["Longitude: -80.125"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"expectation":"toHaveText","params":["Longitude: 66.5"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toHaveLabel","params":["I contain some text"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toHaveText","params":["I contain some text"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"neverAppearingText","isRegex":false},"expectation":"toExist","timeout":500}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"neverAppearingText","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"offscreen-text","isRegex":false},"expectation":"toExist"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"offscreen-text","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"permissionStatus","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"permissionStatus","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"stressContainer","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"subtext-root","isRegex":false},"expectation":"toHaveLabel","params":["This is some subtext"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"textWithCustomInput","isRegex":false},"expectation":"toHaveText","params":["World!"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"expectation":"toHaveValue","params":["0"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"expectation":"toHaveValue","params":["1"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"modifiers":["not"],"expectation":"toHaveValue","params":["0"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"utcDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (UTC): Feb 6th, 2019"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"utcDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (UTC): Jan 11th, 2023"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"label","value":"/^[a-z]* working!+$/i","isRegex":true},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"label","value":"Label Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"/^[a-z]* working!+$/i","isRegex":true},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action activate Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action custom Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action decrement Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action escape Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action increment Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action longpress Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action magicTap Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Active","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Alert Title","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Background","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeOneWay","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeSetState","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeTwoWay","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Button Tapped","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Button Tapped","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Choose a test","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current language: en-US","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current language: es-MX","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current locale: en-US","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current locale: es-MX","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"EventLoop","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"First button pressed!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"From push","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText1","isRegex":false},"expectation":"toBeVisible","params":[1]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText1","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText6","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText6","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText7","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText7","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText8","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText8","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Hello!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"I contain some text","isRegex":false},"expectation":"toHaveId","params":["main-text"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"ID Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Immediate Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Interval Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Interval Skipped-Over!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Label Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"expectation":"toBeVisible","timeout":4000}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press With Duration Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press on Top Left Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press on Top Left Working!!!","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Timeout Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"My Alert Msg","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Obscured by keyboard","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Obscured by keyboard","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Product","isRegex":false},"atIndex":2,"expectation":"toHaveId","params":["ProductId002"]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Sanity","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Say Hello","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Say World","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Custom Duration Pressed","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Custom Duration Pressed","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Pressed","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Tapped","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Shaken, not stirred","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Network Request Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Timeout Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Timeout Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Tap Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"expectation":"toBeVisible","params":[1]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1000","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text12","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text12","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[80]}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text4","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text4","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Traits Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Type Working 123 אֱבּג абв!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Welcome","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"World!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Zero Timeout Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"com.test.itemId","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"detoxtesturlscheme://such-string?arg1=first&arg2=second","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"detoxtesturlscheme://such-string?arg1=first&arg2=second","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"https://my.deeplink.dtx","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"this is a new native root","isRegex":false},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"type","value":"RCTImageView"},"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"expectation","predicate":{"type":"type","value":"RCTImageView"},"modifiers":["not"],"expectation":"toBeVisible"}}
+{"type":"invoke","params":{"type":"webAction","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"body"},"webAction":"getTitle"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"bottomParagraph"},"webAction":"scrollToView"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"clearText"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"focus"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"moveCursorToEnd"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"replaceText","params":["Tester"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"selectAllText"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["Tes"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["Test"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["er"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["r"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["te"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"clearText"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"focus"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"moveCursorToEnd"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"replaceText","params":["Tester"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"runScript","params":["el => {\n              el.type = 'email';\n            }"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"selectAllText"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["0123456789 ABCDEF"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Temp"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Test"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Tester"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["er"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"getText"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { el.textContent = \"Changed\"; throw new Error(\"Error\"); }"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { el.textContent = \"Changed\"; }"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { return el.textContent; }"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["el => {\n          el.textContent = \"Changed\";\n        }"]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScriptWithArgs","params":["(el, text) => { el.textContent = text; }",["Changed"]]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScriptWithArgs","params":["(el, text) => {\n          el.textContent = text;\n        }",["Changed"]]}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"submit"},"webAction":"tap"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"w3link"},"webAction":"tap"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"tag","value":"body"},"webAction":"getCurrentUrl"}}
+{"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"tag","value":"body"},"webAction":"getTitle"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":0,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":1,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":2,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"id","value":"message"},"webExpectation":"toHaveText","params":["This is a dummy webview."]}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"h1"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"h1"},"webModifiers":["not"],"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"class","value":"specialParagraph"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"css","value":".specialParagraph"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"href","value":"https://www.w3schools.com"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"hrefContains","value":"w3schools"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":[""]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":["Name: Tester"]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":["Tester"]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":[""]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":["0123456789"]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":["Tester"]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"nonExistentElement"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"nonExistentElement"},"webModifiers":["not"],"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"pageHeadline"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"pageHeadline"},"webExpectation":"toHaveText","params":["Changed"]}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"label","value":"first-webview"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"name","value":"fname"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"body"},"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":0,"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":100,"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":100,"webModifiers":["not"],"webExpectation":"toExist"}}
+{"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"xpath","value":"//p[@class=\"specialParagraph\"]"},"webExpectation":"toExist"}}
+{"type":"isReady","params":{}}
+{"type":"loginSuccess","params":{"testerConnected":true,"appConnected":true}}
+{"type":"reactNativeReload","params":{}}
+{"type":"setOrientation","params":{"orientation":"landscape"}}
+{"type":"setOrientation","params":{"orientation":"portrait"}}
+{"type":"setSyncSettings","params":{"blacklistURLs":[".*localhost.*"]}}
+{"type":"setSyncSettings","params":{"enabled":false}}
+{"type":"setSyncSettings","params":{"enabled":true}}
+{"type":"shakeDevice","params":{}}
+{"type":"testerDisconnected"}
+{"type":"waitForActive","params":{}}
+{"type":"waitForBackground","params":{}}

--- a/src/steps/description-maker/ios/__fixtures__/long-press-button.json
+++ b/src/steps/description-maker/ios/__fixtures__/long-press-button.json
@@ -1,0 +1,13 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "longPress",
+    "params": [1000],
+    "predicate": {
+      "type": "id",
+      "value": "LongPressButton",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/scroll-to-with-coordinates.json
+++ b/src/steps/description-maker/ios/__fixtures__/scroll-to-with-coordinates.json
@@ -1,0 +1,13 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "scrollTo",
+    "params": ["bottom", 0.2, 0.4],
+    "predicate": {
+      "type": "id",
+      "value": "ScrollView161",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/scroll-to-without-coordinates.json
+++ b/src/steps/description-maker/ios/__fixtures__/scroll-to-without-coordinates.json
@@ -1,0 +1,13 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "scrollTo",
+    "params": ["top", null, null],
+    "predicate": {
+      "type": "id",
+      "value": "ScrollView161",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/scroll-vertical.json
+++ b/src/steps/description-maker/ios/__fixtures__/scroll-vertical.json
@@ -1,0 +1,13 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "scroll",
+    "params": [100, "down", null, null],
+    "predicate": {
+      "type": "id",
+      "value": "ScrollView",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/scroll-with-while.json
+++ b/src/steps/description-maker/ios/__fixtures__/scroll-with-while.json
@@ -1,0 +1,27 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "scroll",
+    "params": [
+      50,
+      "down",
+      null,
+      null
+    ],
+    "predicate": {
+      "type": "id",
+      "value": "ScrollView",
+      "isRegex": false
+    },
+    "while": {
+      "type": "expectation",
+      "predicate": {
+        "type": "text",
+        "value": "Text5",
+        "isRegex": false
+      },
+      "expectation": "toBeVisible"
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-basic-button.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-basic-button.json
@@ -1,0 +1,12 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "id",
+      "value": "SimpleButton",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-compound-and.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-compound-and.json
@@ -1,0 +1,14 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "and",
+      "predicates": [
+        { "type": "id", "value": "button" },
+        { "type": "label", "value": "Click me" }
+      ]
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-compound-button.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-compound-button.json
@@ -1,0 +1,22 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "and",
+      "predicates": [
+        {
+          "type": "id",
+          "value": "CompoundButton",
+          "isRegex": false
+        },
+        {
+          "type": "label",
+          "value": "Compound Button",
+          "isRegex": false
+        }
+      ]
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-indexed-button.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-indexed-button.json
@@ -1,0 +1,12 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "id",
+      "value": "IndexedButton",
+      "atIndex": 1
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-text-element.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-text-element.json
@@ -1,0 +1,12 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "text",
+      "value": "Welcome",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-with-ancestor.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-with-ancestor.json
@@ -1,0 +1,15 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "id",
+      "value": "childButton",
+      "ancestor": {
+        "type": "id",
+        "value": "parentView"
+      }
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/tap-with-traits.json
+++ b/src/steps/description-maker/ios/__fixtures__/tap-with-traits.json
@@ -1,0 +1,11 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "tap",
+    "predicate": {
+      "type": "traits",
+      "value": ["button", "selected"]
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__fixtures__/type-text-input.json
+++ b/src/steps/description-maker/ios/__fixtures__/type-text-input.json
@@ -1,0 +1,13 @@
+{
+  "type": "invoke",
+  "params": {
+    "type": "action",
+    "action": "typeText",
+    "params": ["Hello World"],
+    "predicate": {
+      "type": "id",
+      "value": "TextInput",
+      "isRegex": false
+    }
+  }
+}

--- a/src/steps/description-maker/ios/__snapshots__/ios-description-maker.test.ts.snap
+++ b/src/steps/description-maker/ios/__snapshots__/ios-description-maker.test.ts.snap
@@ -1,0 +1,1740 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS description maker should process everything.jsonl fixture 1`] = `
+"> {"params":{"testerConnected":true,"appConnected":true},"type":"loginSuccess"}
+
+> {"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/661b57d0-5e61-47ba-934f-ed417e5b1bc7.detox.viewhierarchy"}}
+
+> {"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/7994db2b-a838-488b-8dd6-e1ec0809ac84.detox.viewhierarchy"}}
+
+> {"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/a7d78bd4-ff2d-4652-9347-77d0995835c7.detox.viewhierarchy"}}
+
+> {"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/c4a81636-bd67-4a0f-9f53-4730b6c34311.detox.viewhierarchy"}}
+
+> {"type":"captureViewHierarchy","params":{"viewHierarchyURL":"/private/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/cd0aff1f-12ec-4293-b165-98d39121a976.detox.viewhierarchy"}}
+
+> {"type":"cleanup","params":{"stopRunner":false}}
+
+> {"type":"cleanup","params":{"stopRunner":true}}
+
+> {"type":"currentStatus","params":{}}
+
+> {"type":"deliverPayload","params":{"detoxUserActivityDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-jF8YfN/payload.json"}}
+< Deliver payload
++ {}
+
+> {"type":"deliverPayload","params":{"detoxUserNotificationDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-EtGXXg/payload.json"}}
+< Deliver payload
++ {}
+
+> {"type":"deliverPayload","params":{"newInstance":false,"detoxUserActivityDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-if4vil/payload.json","delayPayload":true}}
+< Deliver payload
++ {"delayPayload":true}
+
+> {"type":"deliverPayload","params":{"newInstance":false,"detoxUserNotificationDataURL":"/var/folders/fh/0d3w8yss2_x_5s_448yfc6xr0000gn/T/detoxrand-Nvu0Cj/payload.json","delayPayload":true}}
+< Deliver payload
++ {"delayPayload":true}
+
+> {"type":"deliverPayload","params":{"newInstance":false,"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second","delayPayload":true}}
+< Deliver payload
++ {"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second","delayPayload":true}
+
+> {"type":"deliverPayload","params":{"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second"}}
+< Deliver payload
++ {"url":"detoxtesturlscheme://such-string?arg1=first&arg2=second"}
+
+> {"type":"generateViewHierarchyXml","params":{"shouldInjectTestIds":false}}
+
+> {"type":"generateViewHierarchyXml","params":{"shouldInjectTestIds":true}}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["activate"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "activate" on #View7991
++ {"action":"activate","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["custom"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "custom" on #View7991
++ {"action":"custom","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["decrement"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "decrement" on #View7991
++ {"action":"decrement","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["escape"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "escape" on #View7991
++ {"action":"escape","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["increment"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "increment" on #View7991
++ {"action":"increment","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["longpress"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "longpress" on #View7991
++ {"action":"longpress","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"accessibilityAction","params":["magicTap"],"predicate":{"type":"id","value":"View7991","isRegex":false}}}
+< Activate a11y "magicTap" on #View7991
++ {"action":"magicTap","id":"View7991"}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"and","predicates":[{"type":"type","value":"RCTCustomScrollView"},{"type":"ancestor","predicate":{"type":"id","value":"attrScrollView","isRegex":false}}]}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"and","predicates":[{"type":"type","value":"RCTView"},{"type":"ancestor","predicate":{"type":"id","value":"attrScrollView","isRegex":false}}]}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"attrDatePicker","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"blurredTextInputId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"checkboxId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"draggable","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"focusedTextInputId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"sliderId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"textGroupRoot","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"textViewId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"getAttributes","predicate":{"type":"id","value":"viewId","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,0.5,0.5,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0,0,1,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0.5,0.5,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,0.5,0.5,0.5,0.5,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,1,0,0,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[1000,1,0,1,0,"fast",0],"predicate":{"type":"id","value":"draggable","isRegex":false},"targetElement":{"predicate":{"type":"id","value":"DragAndDropTarget","isRegex":false}}}}
+< Long press #draggable
++ {"duration":1000,"id":"draggable"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[null,1500],"predicate":{"type":"text","value":"Long Press Me 1.5s","isRegex":false}}}
+< Long press "Long Press Me 1.5s"
++ {"text":"Long Press Me 1.5s"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[null,null],"predicate":{"type":"text","value":"Tap Me","isRegex":false}}}
+< Long press "Tap Me"
++ {"text":"Tap Me"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[{"x":15,"y":15},null],"predicate":{"type":"text","value":"Long Press on Top Left","isRegex":false}}}
+< Long press "Long Press on Top Left"
++ {"duration":{"x":15,"y":15},"text":"Long Press on Top Left"}
+
+> {"type":"invoke","params":{"type":"action","action":"longPress","params":[{"x":5,"y":5},null],"predicate":{"type":"text","value":"Long Press on Top Left","isRegex":false}}}
+< Long press "Long Press on Top Left"
++ {"duration":{"x":5,"y":5},"text":"Long Press on Top Left"}
+
+> {"type":"invoke","params":{"type":"action","action":"multiTap","params":[3],"predicate":{"type":"id","value":"UniqueId819","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"replaceText","params":["1600"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_delay","isRegex":false}}}
+< Replace text in #UniqueId_Animat…nsScreen_delay
++ {"text":"1600","id":"UniqueId_AnimationsScreen_delay"}
+
+> {"type":"invoke","params":{"type":"action","action":"replaceText","params":["2000"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_duration","isRegex":false}}}
+< Replace text in #UniqueId_Animat…creen_duration
++ {"text":"2000","id":"UniqueId_AnimationsScreen_duration"}
+
+> {"type":"invoke","params":{"type":"action","action":"replaceText","params":["4"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_numberOfIterations","isRegex":false}}}
+< Replace text in #UniqueId_Animat…erOfIterations
++ {"text":"4","id":"UniqueId_AnimationsScreen_numberOfIterations"}
+
+> {"type":"invoke","params":{"type":"action","action":"replaceText","params":["500"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_delay","isRegex":false}}}
+< Replace text in #UniqueId_Animat…nsScreen_delay
++ {"text":"500","id":"UniqueId_AnimationsScreen_delay"}
+
+> {"type":"invoke","params":{"type":"action","action":"replaceText","params":["5000"],"predicate":{"type":"id","value":"UniqueId_AnimationsScreen_duration","isRegex":false}}}
+< Replace text in #UniqueId_Animat…creen_duration
++ {"text":"5000","id":"UniqueId_AnimationsScreen_duration"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[10,"down",null,null],"predicate":{"type":"id","value":"FSScrollActions.scrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"expectation":"toBeVisible","params":[100]}}}
+< Scroll down on #FSScrollActions.scrollView while waiting for "Text16" to be visible
++ {"direction":"down","distance":10,"id":"FSScrollActions.scrollView","while_text":"Text16"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[10,"down",null,null],"predicate":{"type":"id","value":"FSScrollActions.scrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"expectation":"toBeVisible","params":[50]}}}
+< Scroll down on #FSScrollActions.scrollView while waiting for "Text16" to be visible
++ {"direction":"down","distance":10,"id":"FSScrollActions.scrollView","while_text":"Text16"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[100,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll down on #ScrollView161
++ {"direction":"down","distance":100,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[100,"up",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll up on #ScrollView161
++ {"direction":"up","distance":100,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[1000,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll down on #ScrollView161
++ {"direction":"down","distance":1000,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[200,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll down on #ScrollView161
++ {"direction":"down","distance":200,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[200,"right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll right on #ScrollViewH
++ {"direction":"right","distance":200,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"left",0.2,0.4],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll left on #ScrollViewH
++ {"direction":"left","distance":220,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"right",0.8,0.6],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll right on #ScrollViewH
++ {"direction":"right","distance":220,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[220,"right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll right on #ScrollViewH
++ {"direction":"right","distance":220,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text1000","isRegex":false},"expectation":"toBeVisible"}}}
+< Scroll down on #ScrollView while waiting for "Text1000" to be visible
++ {"direction":"down","distance":50,"id":"ScrollView","while_text":"Text1000"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"expectation":"toBeVisible"}}}
+< Scroll down on #ScrollView while waiting for "Text5" to be visible
++ {"direction":"down","distance":50,"id":"ScrollView","while_text":"Text5"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[50,"down",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false},"while":{"type":"expectation","predicate":{"type":"text","value":"Index","isRegex":false},"atIndex":1,"expectation":"toBeVisible"}}}
+< Scroll down on #ScrollView161 while waiting for "Index" to be visible
++ {"direction":"down","distance":50,"id":"ScrollView161","while_text":"Index"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[550,"down",0.8,0.6],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll down on #ScrollView161
++ {"direction":"down","distance":550,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scroll","params":[550,"up",0.2,0.4],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll up on #ScrollView161
++ {"direction":"up","distance":550,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",0.2,0.4],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll to bottom on #ScrollView161
++ {"edge":"bottom","x":0.2,"y":0.4,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll to bottom on #ScrollView161
++ {"edge":"bottom","id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false}}}
+< Scroll to bottom on #ShowOverlayViewButton
++ {"edge":"bottom","id":"ShowOverlayViewButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["bottom",null,null],"predicate":{"type":"id","value":"VerticalScrollView","isRegex":false}}}
+< Scroll to bottom on #VerticalScrollView
++ {"edge":"bottom","id":"VerticalScrollView"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["left",0.2,0.4],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll to left on #ScrollViewH
++ {"edge":"left","x":0.2,"y":0.4,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["left",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll to left on #ScrollViewH
++ {"edge":"left","id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["right",0.8,0.6],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll to right on #ScrollViewH
++ {"edge":"right","x":0.8,"y":0.6,"id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["right",null,null],"predicate":{"type":"id","value":"ScrollViewH","isRegex":false}}}
+< Scroll to right on #ScrollViewH
++ {"edge":"right","id":"ScrollViewH"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["top",0.8,0.6],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll to top on #ScrollView161
++ {"edge":"top","x":0.8,"y":0.6,"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"scrollTo","params":["top",null,null],"predicate":{"type":"id","value":"ScrollView161","isRegex":false}}}
+< Scroll to top on #ScrollView161
++ {"edge":"top","id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"action","action":"setColumnToValue","params":[0,"c"],"predicate":{"type":"id","value":"pickerView","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"setColumnToValue","params":[1,"6"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2019-02-06T05:10:00-08:00","ISO8601"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+< Set date picker #datePicker 2019-02-06T05:10:00-08:00
++ {"id":"datePicker","date":"2019-02-06T05:10:00-08:00","format":"ISO8601"}
+
+> {"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2019/02/06 13:10","yyyy/MM/dd HH:mm"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+< Set date picker #datePicker 2019/02/06 13:10
++ {"id":"datePicker","date":"2019/02/06 13:10","format":"yyyy/MM/dd HH:mm"}
+
+> {"type":"invoke","params":{"type":"action","action":"setDatePickerDate","params":["2023-01-11T10:41:26Z","ISO8601"],"predicate":{"type":"id","value":"datePicker","isRegex":false}}}
+< Set date picker #datePicker 2023-01-11T10:41:26Z
++ {"id":"datePicker","date":"2023-01-11T10:41:26Z","format":"ISO8601"}
+
+> {"type":"invoke","params":{"type":"action","action":"swipe","atIndex":0,"params":["down","fast",0.7,null,null],"predicate":{"type":"text","value":"Index","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["elementScreenshot.horiz"],"predicate":{"type":"id","value":"fancyElement","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["elementScreenshot.vert"],"predicate":{"type":"id","value":"fancyElement","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["focus-on-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["focus-on-input-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["move-cursor-to-end-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["move-cursor-to-end-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["scroll-to-view-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["select-all-text-in-content-editable-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["select-all-text-in-webview"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["tap-on-cross-origin-frame-element"],"predicate":{"type":"id","value":"webView","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["type-text-in-cross-origin-frame"],"predicate":{"type":"id","value":"webView","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["typing-keep-cursor-position-webview-content-editable-1"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"takeScreenshot","params":["typing-keep-cursor-position-webview-input-1"],"predicate":{"type":"id","value":"webViewFormWithScrolling","isRegex":false}}}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","atIndex":0,"predicate":{"type":"text","value":"Index","isRegex":false}}}
+< Tap "Index"
++ {"text":"Index"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","atIndex":3,"predicate":{"type":"text","value":"Index","isRegex":false}}}
+< Tap "Index"
++ {"text":"Index"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"/UniqueId\\\\d{3}/","isRegex":true}}}
+< Tap [id] ~ /UniqueId\\d{3}/
++ {"id":"/UniqueId\\\\d{3}/"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"AlertScreen.Button","isRegex":false}}}
+< Tap #AlertScreen.Button
++ {"id":"AlertScreen.Button"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"Immediate","isRegex":false}}}
+< Tap #Immediate
++ {"id":"Immediate"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"IntervalIgnore","isRegex":false}}}
+< Tap #IntervalIgnore
++ {"id":"IntervalIgnore"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"LongNetworkRequest","isRegex":false}}}
+< Tap #LongNetworkRequest
++ {"id":"LongNetworkRequest"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"OverlayView","isRegex":false}}}
+< Tap #OverlayView
++ {"id":"OverlayView"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShortNetworkRequest","isRegex":false}}}
+< Tap #ShortNetworkRequest
++ {"id":"ShortNetworkRequest"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowDismissibleAlertButton","isRegex":false}}}
+< Tap #ShowDismissibleAlertButton
++ {"id":"ShowDismissibleAlertButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false}}}
+< Tap #ShowOverlayViewButton
++ {"id":"ShowOverlayViewButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false}}}
+< Tap #ShowOverlayWindowButton
++ {"id":"ShowOverlayWindowButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"SkipOverInterval","isRegex":false}}}
+< Tap #SkipOverInterval
++ {"id":"SkipOverInterval"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutIgnoreLong","isRegex":false}}}
+< Tap #TimeoutIgnoreLong
++ {"id":"TimeoutIgnoreLong"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutIgnoreShort","isRegex":false}}}
+< Tap #TimeoutIgnoreShort
++ {"id":"TimeoutIgnoreShort"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutShort","isRegex":false}}}
+< Tap #TimeoutShort
++ {"id":"TimeoutShort"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"TimeoutZero","isRegex":false}}}
+< Tap #TimeoutZero
++ {"id":"TimeoutZero"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId345","isRegex":false}}}
+< Tap #UniqueId345
++ {"id":"UniqueId345"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId819","isRegex":false}}}
+< Tap #UniqueId819
++ {"id":"UniqueId819"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_enableLoop","isRegex":false}}}
+< Tap #UniqueId_Animat…een_enableLoop
++ {"id":"UniqueId_AnimationsScreen_enableLoop"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_startButton","isRegex":false}}}
+< Tap #UniqueId_Animat…en_startButton
++ {"id":"UniqueId_AnimationsScreen_startButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"closeButton","isRegex":false}}}
+< Tap #closeButton
++ {"id":"closeButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"get_location_button","isRegex":false}}}
+< Tap #get_location_button
++ {"id":"get_location_button"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"goButton","isRegex":false}}}
+< Tap #goButton
++ {"id":"goButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"keyboardHelloButton","isRegex":false}}}
+< Tap #keyboardHelloButton
++ {"id":"keyboardHelloButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"moveHalfVisible","isRegex":false}}}
+< Tap #moveHalfVisible
++ {"id":"moveHalfVisible"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"nonExistentId","isRegex":false}}}
+< Tap #nonExistentId
++ {"id":"nonExistentId"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"requestPermissionButton","isRegex":false}}}
+< Tap #requestPermissionButton
++ {"id":"requestPermissionButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"switchOrientation","isRegex":false}}}
+< Tap #switchOrientation
++ {"id":"switchOrientation"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"textWithCustomInput","isRegex":false}}}
+< Tap #textWithCustomInput
++ {"id":"textWithCustomInput"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle","isRegex":false}}}
+< Tap #toggle
++ {"id":"toggle"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle2ndWebviewButton","isRegex":false}}}
+< Tap #toggle2ndWebviewButton
++ {"id":"toggle2ndWebviewButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggle3rdWebviewButton","isRegex":false}}}
+< Tap #toggle3rdWebviewButton
++ {"id":"toggle3rdWebviewButton"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggleDatePicker","isRegex":false}}}
+< Tap #toggleDatePicker
++ {"id":"toggleDatePicker"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"id","value":"toggleScrollOverlays","isRegex":false}}}
+< Tap #toggleScrollOverlays
++ {"id":"toggleScrollOverlays"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"label","value":"Label","isRegex":false}}}
+< Tap "Label"
++ {"label":"Label"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Actions","isRegex":false}}}
+< Tap "Actions"
++ {"text":"Actions"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Alerts","isRegex":false}}}
+< Tap "Alerts"
++ {"text":"Alerts"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Assertions","isRegex":false}}}
+< Tap "Assertions"
++ {"text":"Assertions"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Attributes","isRegex":false}}}
+< Tap "Attributes"
++ {"text":"Attributes"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge OneWay Stress","isRegex":false}}}
+< Tap "Bridge OneWay Stress"
++ {"text":"Bridge OneWay Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge TwoWay Stress","isRegex":false}}}
+< Tap "Bridge TwoWay Stress"
++ {"text":"Bridge TwoWay Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Bridge setState Stress","isRegex":false}}}
+< Tap "Bridge setState Stress"
++ {"text":"Bridge setState Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Button 1","isRegex":false}}}
+< Tap "Button 1"
++ {"text":"Button 1"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Cancel","isRegex":false}}}
+< Tap "Cancel"
++ {"text":"Cancel"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 1","isRegex":false}}}
+< Tap "Consecutive Stress 1"
++ {"text":"Consecutive Stress 1"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 10","isRegex":false}}}
+< Tap "Consecutive Stress 10"
++ {"text":"Consecutive Stress 10"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 11","isRegex":false}}}
+< Tap "Consecutive Stress 11"
++ {"text":"Consecutive Stress 11"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 12","isRegex":false}}}
+< Tap "Consecutive Stress 12"
++ {"text":"Consecutive Stress 12"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 13","isRegex":false}}}
+< Tap "Consecutive Stress 13"
++ {"text":"Consecutive Stress 13"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 14","isRegex":false}}}
+< Tap "Consecutive Stress 14"
++ {"text":"Consecutive Stress 14"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 15","isRegex":false}}}
+< Tap "Consecutive Stress 15"
++ {"text":"Consecutive Stress 15"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 16","isRegex":false}}}
+< Tap "Consecutive Stress 16"
++ {"text":"Consecutive Stress 16"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 17","isRegex":false}}}
+< Tap "Consecutive Stress 17"
++ {"text":"Consecutive Stress 17"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 18","isRegex":false}}}
+< Tap "Consecutive Stress 18"
++ {"text":"Consecutive Stress 18"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 19","isRegex":false}}}
+< Tap "Consecutive Stress 19"
++ {"text":"Consecutive Stress 19"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 2","isRegex":false}}}
+< Tap "Consecutive Stress 2"
++ {"text":"Consecutive Stress 2"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 20","isRegex":false}}}
+< Tap "Consecutive Stress 20"
++ {"text":"Consecutive Stress 20"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 3","isRegex":false}}}
+< Tap "Consecutive Stress 3"
++ {"text":"Consecutive Stress 3"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 4","isRegex":false}}}
+< Tap "Consecutive Stress 4"
++ {"text":"Consecutive Stress 4"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 5","isRegex":false}}}
+< Tap "Consecutive Stress 5"
++ {"text":"Consecutive Stress 5"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 6","isRegex":false}}}
+< Tap "Consecutive Stress 6"
++ {"text":"Consecutive Stress 6"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 7","isRegex":false}}}
+< Tap "Consecutive Stress 7"
++ {"text":"Consecutive Stress 7"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 8","isRegex":false}}}
+< Tap "Consecutive Stress 8"
++ {"text":"Consecutive Stress 8"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Consecutive Stress 9","isRegex":false}}}
+< Tap "Consecutive Stress 9"
++ {"text":"Consecutive Stress 9"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Crash","isRegex":false}}}
+< Tap "Crash"
++ {"text":"Crash"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Custom Keyboard","isRegex":false}}}
+< Tap "Custom Keyboard"
++ {"text":"Custom Keyboard"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"DatePicker","isRegex":false}}}
+< Tap "DatePicker"
++ {"text":"DatePicker"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Device Tap","isRegex":false}}}
+< Tap "Device Tap"
++ {"text":"Device Tap"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Dismiss","isRegex":false}}}
+< Tap "Dismiss"
++ {"text":"Dismiss"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Drag And Drop","isRegex":false}}}
+< Tap "Drag And Drop"
++ {"text":"Drag And Drop"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Element-Screenshots","isRegex":false}}}
+< Tap "Element-Screenshots"
++ {"text":"Element-Screenshots"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"EventLoop Stress","isRegex":false}}}
+< Tap "EventLoop Stress"
++ {"text":"EventLoop Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"FS Scroll Actions","isRegex":false}}}
+< Tap "FS Scroll Actions"
++ {"text":"FS Scroll Actions"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Init URL","isRegex":false}}}
+< Tap "Init URL"
++ {"text":"Init URL"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"JS","isRegex":false}}}
+< Tap "JS"
++ {"text":"JS"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Language","isRegex":false}}}
+< Tap "Language"
++ {"text":"Language"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Location","isRegex":false}}}
+< Tap "Location"
++ {"text":"Location"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Matchers","isRegex":false}}}
+< Tap "Matchers"
++ {"text":"Matchers"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Native","isRegex":false}}}
+< Tap "Native"
++ {"text":"Native"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Network","isRegex":false}}}
+< Tap "Network"
++ {"text":"Network"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Next","isRegex":false}}}
+< Tap "Next"
++ {"text":"Next"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Not existing","isRegex":false}}}
+< Tap "Not existing"
++ {"text":"Not existing"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"OK","isRegex":false}}}
+< Tap "OK"
++ {"text":"OK"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Orientation","isRegex":false}}}
+< Tap "Orientation"
++ {"text":"Orientation"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Overlay","isRegex":false}}}
+< Tap "Overlay"
++ {"text":"Overlay"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Permissions","isRegex":false}}}
+< Tap "Permissions"
++ {"text":"Permissions"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Picker","isRegex":false}}}
+< Tap "Picker"
++ {"text":"Picker"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"RN Animations","isRegex":false}}}
+< Tap "RN Animations"
++ {"text":"RN Animations"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Sanity","isRegex":false}}}
+< Tap "Sanity"
++ {"text":"Sanity"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Say Hello","isRegex":false}}}
+< Tap "Say Hello"
++ {"text":"Say Hello"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Say World","isRegex":false}}}
+< Tap "Say World"
++ {"text":"Say World"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Shake","isRegex":false}}}
+< Tap "Shake"
++ {"text":"Shake"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Stress","isRegex":false}}}
+< Tap "Stress"
++ {"text":"Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch Root","isRegex":false}}}
+< Tap "Switch Root"
++ {"text":"Switch Root"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch to a new native root","isRegex":false}}}
+< Tap "Switch to a new native root"
++ {"text":"Switch to a new native root"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Switch to multiple react roots","isRegex":false}}}
+< Tap "Switch to multiple react roots"
++ {"text":"Switch to multiple react roots"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"System Dialogs","isRegex":false}}}
+< Tap "System Dialogs"
++ {"text":"System Dialogs"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Tap Me","isRegex":false}}}
+< Tap "Tap Me"
++ {"text":"Tap Me"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Timeouts","isRegex":false}}}
+< Tap "Timeouts"
++ {"text":"Timeouts"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"VirtualizedList Stress","isRegex":false}}}
+< Tap "VirtualizedList Stress"
++ {"text":"VirtualizedList Stress"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Visibility Debug Artifacts","isRegex":false}}}
+< Tap "Visibility Debug Artifacts"
++ {"text":"Visibility Debug Artifacts"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"Visibility Expectation","isRegex":false}}}
+< Tap "Visibility Expectation"
++ {"text":"Visibility Expectation"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"WaitFor","isRegex":false}}}
+< Tap "WaitFor"
++ {"text":"WaitFor"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"text","value":"WebView","isRegex":false}}}
+< Tap "WebView"
++ {"text":"WebView"}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"traits","value":["button"]}}}
+< Tap [button]
++ {"traits":["button"]}
+
+> {"type":"invoke","params":{"type":"action","action":"tap","predicate":{"type":"type","value":"RCTImageView"}}}
+< Tap [type] = RCTImageView
++ {"type":"RCTImageView"}
+
+> {"type":"invoke","params":{"type":"action","action":"typeText","params":["Type Working 123 אֱבּג абв!!!"],"predicate":{"type":"id","value":"UniqueId937","isRegex":false}}}
+< Type text in #UniqueId937
++ {"text":"Type Working 123 אֱבּג абв!!!","id":"UniqueId937"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Father883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Father883 AND [ancestor] = ) not to exist
++ {"id":"Father883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Father883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Father883 AND [descendant] = ) to exist
++ {"id":"Father883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandfather883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Grandfather883 AND [ancestor] = ) not to exist
++ {"id":"Grandfather883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandfather883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Grandfather883 AND [descendant] = ) to exist
++ {"id":"Grandfather883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Father883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Grandson883 AND [ancestor] = ) to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandfather883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Grandson883 AND [ancestor] = ) to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Son883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Grandson883 AND [ancestor] = ) to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Father883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Grandson883 AND [descendant] = ) not to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandfather883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Grandson883 AND [descendant] = ) not to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Grandson883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Son883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Grandson883 AND [descendant] = ) not to exist
++ {"id":"Grandson883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Son883","isRegex":false},{"type":"ancestor","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#Son883 AND [ancestor] = ) not to exist
++ {"id":"Son883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"Son883","isRegex":false},{"type":"descendant","predicate":{"type":"id","value":"Grandson883","isRegex":false}}]},"expectation":"toExist"}}
+< Expect (#Son883 AND [descendant] = ) to exist
++ {"id":"Son883"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"label","value":"RandomJunk","isRegex":false}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#UniqueId345 AND "RandomJunk") not to exist
++ {"id":"UniqueId345","label":"RandomJunk"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"text","value":"ID","isRegex":false}]},"expectation":"toExist"}}
+< Expect (#UniqueId345 AND "ID") to exist
++ {"id":"UniqueId345","text":"ID"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"text","value":"RandomJunk","isRegex":false}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#UniqueId345 AND "RandomJunk") not to exist
++ {"id":"UniqueId345","text":"RandomJunk"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"and","predicates":[{"type":"id","value":"UniqueId345","isRegex":false},{"type":"traits","value":["button"]}]},"modifiers":["not"],"expectation":"toExist"}}
+< Expect (#UniqueId345 AND [button]) not to exist
++ {"id":"UniqueId345","traits":["button"]}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["Cancel Pressed"]}}
+< Expect #AlertScreen.Text to have text Cancel Pressed
++ {"id":"AlertScreen.Text","expected":"Cancel Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["Not Pressed"]}}
+< Expect #AlertScreen.Text to have text Not Pressed
++ {"id":"AlertScreen.Text","expected":"Not Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"AlertScreen.Text","isRegex":false},"expectation":"toHaveText","params":["OK Pressed"]}}
+< Expect #AlertScreen.Text to have text OK Pressed
++ {"id":"AlertScreen.Text","expected":"OK Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"LongNetworkRequest","isRegex":false},"expectation":"toBeVisible","timeout":4000}}
+< Expect #LongNetworkRequest to be visible
++ {"id":"LongNetworkRequest"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"RandomJunk959","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+< Expect #RandomJunk959 not to exist
++ {"id":"RandomJunk959"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ScrollView161","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #ScrollView161 to be visible
++ {"id":"ScrollView161"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowDismissibleAlertButton","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #ShowDismissibleAlertButton to be visible
++ {"id":"ShowDismissibleAlertButton"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayViewButton","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #ShowOverlayViewButton to be visible
++ {"id":"ShowOverlayViewButton"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #ShowOverlayWindowButton to be visible
++ {"id":"ShowOverlayWindowButton"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"ShowOverlayWindowButton","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect #ShowOverlayWindowButton not to be visible
++ {"id":"ShowOverlayWindowButton"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId819","isRegex":false},"expectation":"toHaveText","params":["Taps: 3"]}}
+< Expect #UniqueId819 to have text Taps: 3
++ {"id":"UniqueId819","expected":"Taps: 3"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #UniqueId_Animat…rAnimationText to be visible
++ {"id":"UniqueId_AnimationsScreen_afterAnimationText"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"expectation":"toExist"}}
+< Expect #UniqueId_Animat…rAnimationText to exist
++ {"id":"UniqueId_AnimationsScreen_afterAnimationText"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_afterAnimationText","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+< Expect #UniqueId_Animat…rAnimationText not to exist
++ {"id":"UniqueId_AnimationsScreen_afterAnimationText"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"UniqueId_AnimationsScreen_enableLoop","isRegex":false},"expectation":"toHaveValue","params":["1"]}}
+< Expect #UniqueId_Animat…een_enableLoop to have value 1
++ {"id":"UniqueId_AnimationsScreen_enableLoop","expected":"1"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #calendar to be visible
++ {"id":"calendar"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #calendar to have text blocked
++ {"id":"calendar","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #calendar to have text denied
++ {"id":"calendar","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"calendar","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #calendar to have text granted
++ {"id":"calendar","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #camera to be visible
++ {"id":"camera"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #camera to have text blocked
++ {"id":"camera","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #camera to have text denied
++ {"id":"camera","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"camera","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #camera to have text granted
++ {"id":"camera","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"expectation":"toExist","timeout":5000}}
+< Expect #changeExistenceByToggle to exist
++ {"id":"changeExistenceByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"modifiers":["not"],"expectation":"toExist","timeout":5000}}
+< Expect #changeExistenceByToggle not to exist
++ {"id":"changeExistenceByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeExistenceByToggle","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+< Expect #changeExistenceByToggle not to exist
++ {"id":"changeExistenceByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"expectation":"toBeFocused","timeout":5000}}
+< Expect #changeFocusByToggle to be focused
++ {"id":"changeFocusByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"modifiers":["not"],"expectation":"toBeFocused","timeout":5000}}
+< Expect #changeFocusByToggle not to be focused
++ {"id":"changeFocusByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"changeFocusByToggle","isRegex":false},"modifiers":["not"],"expectation":"toBeFocused"}}
+< Expect #changeFocusByToggle not to be focused
++ {"id":"changeFocusByToggle"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #contacts to be visible
++ {"id":"contacts"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #contacts to have text blocked
++ {"id":"contacts","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #contacts to have text denied
++ {"id":"contacts","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"contacts","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #contacts to have text granted
++ {"id":"contacts","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toExist"}}
+< Expect #currentOrientation to exist
++ {"id":"currentOrientation"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toHaveText","params":["Landscape"]}}
+< Expect #currentOrientation to have text Landscape
++ {"id":"currentOrientation","expected":"Landscape"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"currentOrientation","isRegex":false},"expectation":"toHaveText","params":["Portrait"]}}
+< Expect #currentOrientation to have text Portrait
++ {"id":"currentOrientation","expected":"Portrait"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #faceid to be visible
++ {"id":"faceid"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #faceid to have text blocked
++ {"id":"faceid","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #faceid to have text denied
++ {"id":"faceid","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"faceid","isRegex":false},"expectation":"toHaveText","params":["unavailable"]}}
+< Expect #faceid to have text unavailable
++ {"id":"faceid","expected":"unavailable"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"expectation":"toBeVisible","params":[25],"timeout":2000}}
+< Expect #halfVisible to be visible by 2500%
++ {"id":"halfVisible","expected":25}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"expectation":"toBeVisible","params":[50]}}
+< Expect #halfVisible to be visible by 5000%
++ {"id":"halfVisible","expected":50}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[26],"timeout":2000}}
+< Expect #halfVisible not to be visible by 2600%
++ {"id":"halfVisible","expected":26}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"halfVisible","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[51]}}
+< Expect #halfVisible not to be visible by 5100%
++ {"id":"halfVisible","expected":51}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"localDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (Local): Feb 6th, 2019"]}}
+< Expect #localDateLabel to have text Date (Local): Feb 6th, 2019
++ {"id":"localDateLabel","expected":"Date (Local): Feb 6th, 2019"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #location_always to be visible
++ {"id":"location_always"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #location_always to have text blocked
++ {"id":"location_always","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #location_always to have text denied
++ {"id":"location_always","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_always","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #location_always to have text granted
++ {"id":"location_always","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_error","isRegex":false},"expectation":"toBeVisible","timeout":3000}}
+< Expect #location_error to be visible
++ {"id":"location_error"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"expectation":"toHaveText","params":["Latitude: -80.125"],"timeout":5000}}
+< Expect #location_latitude to have text Latitude: -80.125
++ {"id":"location_latitude","expected":"Latitude: -80.125"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"expectation":"toHaveText","params":["Latitude: 66.5"],"timeout":5000}}
+< Expect #location_latitude to have text Latitude: 66.5
++ {"id":"location_latitude","expected":"Latitude: 66.5"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_latitude","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect #location_latitude not to be visible
++ {"id":"location_latitude"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"expectation":"toHaveText","params":["Longitude: -80.125"]}}
+< Expect #location_longitude to have text Longitude: -80.125
++ {"id":"location_longitude","expected":"Longitude: -80.125"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"expectation":"toHaveText","params":["Longitude: 66.5"]}}
+< Expect #location_longitude to have text Longitude: 66.5
++ {"id":"location_longitude","expected":"Longitude: 66.5"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_longitude","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect #location_longitude not to be visible
++ {"id":"location_longitude"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #location_when_in_use to be visible
++ {"id":"location_when_in_use"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #location_when_in_use to have text blocked
++ {"id":"location_when_in_use","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #location_when_in_use to have text denied
++ {"id":"location_when_in_use","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"location_when_in_use","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #location_when_in_use to have text granted
++ {"id":"location_when_in_use","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #main-text to be visible
++ {"id":"main-text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toHaveLabel","params":["I contain some text"]}}
+< Expect #main-text to have label I contain some text
++ {"id":"main-text","expected":"I contain some text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"main-text","isRegex":false},"expectation":"toHaveText","params":["I contain some text"]}}
+< Expect #main-text to have text I contain some text
++ {"id":"main-text","expected":"I contain some text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #medialibrary to be visible
++ {"id":"medialibrary"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #medialibrary to have text blocked
++ {"id":"medialibrary","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #medialibrary to have text denied
++ {"id":"medialibrary","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"medialibrary","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #medialibrary to have text granted
++ {"id":"medialibrary","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #microphone to be visible
++ {"id":"microphone"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #microphone to have text blocked
++ {"id":"microphone","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #microphone to have text denied
++ {"id":"microphone","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"microphone","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #microphone to have text granted
++ {"id":"microphone","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"neverAppearingText","isRegex":false},"expectation":"toExist","timeout":500}}
+< Expect #neverAppearingText to exist
++ {"id":"neverAppearingText"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"neverAppearingText","isRegex":false},"modifiers":["not"],"expectation":"toExist"}}
+< Expect #neverAppearingText not to exist
++ {"id":"neverAppearingText"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"offscreen-text","isRegex":false},"expectation":"toExist"}}
+< Expect #offscreen-text to exist
++ {"id":"offscreen-text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"offscreen-text","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect #offscreen-text not to be visible
++ {"id":"offscreen-text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"permissionStatus","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #permissionStatus to have text denied
++ {"id":"permissionStatus","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"permissionStatus","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #permissionStatus to have text granted
++ {"id":"permissionStatus","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #photo_library to be visible
++ {"id":"photo_library"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #photo_library to have text blocked
++ {"id":"photo_library","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #photo_library to have text denied
++ {"id":"photo_library","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #photo_library to have text granted
++ {"id":"photo_library","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #photo_library_add_only to be visible
++ {"id":"photo_library_add_only"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #photo_library_add_only to have text denied
++ {"id":"photo_library_add_only","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"photo_library_add_only","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #photo_library_add_only to have text granted
++ {"id":"photo_library_add_only","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #reminders to be visible
++ {"id":"reminders"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #reminders to have text blocked
++ {"id":"reminders","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #reminders to have text denied
++ {"id":"reminders","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"reminders","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #reminders to have text granted
++ {"id":"reminders","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #siri to be visible
++ {"id":"siri"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #siri to have text blocked
++ {"id":"siri","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #siri to have text denied
++ {"id":"siri","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"siri","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #siri to have text granted
++ {"id":"siri","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #speech to be visible
++ {"id":"speech"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #speech to have text blocked
++ {"id":"speech","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #speech to have text denied
++ {"id":"speech","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"speech","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #speech to have text granted
++ {"id":"speech","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"stressContainer","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #stressContainer to be visible
++ {"id":"stressContainer"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"subtext-root","isRegex":false},"expectation":"toHaveLabel","params":["This is some subtext"]}}
+< Expect #subtext-root to have label This is some subtext
++ {"id":"subtext-root","expected":"This is some subtext"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"textWithCustomInput","isRegex":false},"expectation":"toHaveText","params":["World!"]}}
+< Expect #textWithCustomInput to have text World!
++ {"id":"textWithCustomInput","expected":"World!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"expectation":"toHaveValue","params":["0"]}}
+< Expect #toggle to have value 0
++ {"id":"toggle","expected":"0"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"expectation":"toHaveValue","params":["1"]}}
+< Expect #toggle to have value 1
++ {"id":"toggle","expected":"1"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"toggle","isRegex":false},"modifiers":["not"],"expectation":"toHaveValue","params":["0"]}}
+< Expect #toggle not to have value 0
++ {"id":"toggle","expected":"0"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toBeVisible"}}
+< Expect #userTracking to be visible
++ {"id":"userTracking"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["blocked"]}}
+< Expect #userTracking to have text blocked
++ {"id":"userTracking","expected":"blocked"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["denied"]}}
+< Expect #userTracking to have text denied
++ {"id":"userTracking","expected":"denied"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"userTracking","isRegex":false},"expectation":"toHaveText","params":["granted"]}}
+< Expect #userTracking to have text granted
++ {"id":"userTracking","expected":"granted"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"utcDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (UTC): Feb 6th, 2019"]}}
+< Expect #utcDateLabel to have text Date (UTC): Feb 6th, 2019
++ {"id":"utcDateLabel","expected":"Date (UTC): Feb 6th, 2019"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"id","value":"utcDateLabel","isRegex":false},"expectation":"toHaveText","params":["Date (UTC): Jan 11th, 2023"]}}
+< Expect #utcDateLabel to have text Date (UTC): Jan 11th, 2023
++ {"id":"utcDateLabel","expected":"Date (UTC): Jan 11th, 2023"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"label","value":"/^[a-z]* working!+$/i","isRegex":true},"expectation":"toBeVisible"}}
+< Expect [label] ~ /^[a-z]* working!+$/i to be visible
++ {"label":"/^[a-z]* working!+$/i"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"label","value":"Label Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Label Working!!!" to be visible
++ {"label":"Label Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"/^[a-z]* working!+$/i","isRegex":true},"expectation":"toBeVisible"}}
+< Expect [text] ~ /^[a-z]* working!+$/i to be visible
++ {"text":"/^[a-z]* working!+$/i"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action activate Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…ate Working!!!" to be visible
++ {"text":"Accessibility Action activate Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action custom Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…tom Working!!!" to be visible
++ {"text":"Accessibility Action custom Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action decrement Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…ent Working!!!" to be visible
++ {"text":"Accessibility Action decrement Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action escape Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…ape Working!!!" to be visible
++ {"text":"Accessibility Action escape Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action increment Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…ent Working!!!" to be visible
++ {"text":"Accessibility Action increment Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action longpress Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…ess Working!!!" to be visible
++ {"text":"Accessibility Action longpress Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Accessibility Action magicTap Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Accessibility A…Tap Working!!!" to be visible
++ {"text":"Accessibility Action magicTap Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Active","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Active" to be visible
++ {"text":"Active"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Alert Title","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Alert Title" to be visible
++ {"text":"Alert Title"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Background","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Background" to be visible
++ {"text":"Background"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeOneWay","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "BridgeOneWay" to be visible
++ {"text":"BridgeOneWay"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeSetState","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "BridgeSetState" to be visible
++ {"text":"BridgeSetState"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"BridgeTwoWay","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "BridgeTwoWay" to be visible
++ {"text":"BridgeTwoWay"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Button Tapped","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Button Tapped" to be visible
++ {"text":"Button Tapped"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Button Tapped","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Button Tapped" not to be visible
++ {"text":"Button Tapped"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Choose a test","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Choose a test" to be visible
++ {"text":"Choose a test"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current language: en-US","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Current language: en-US" to be visible
++ {"text":"Current language: en-US"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current language: es-MX","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Current language: es-MX" to be visible
++ {"text":"Current language: es-MX"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current locale: en-US","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Current locale: en-US" to be visible
++ {"text":"Current locale: en-US"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Current locale: es-MX","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Current locale: es-MX" to be visible
++ {"text":"Current locale: es-MX"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"EventLoop","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "EventLoop" to be visible
++ {"text":"EventLoop"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"First button pressed!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "First button pressed!!!" to be visible
++ {"text":"First button pressed!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"From push","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "From push" to be visible
++ {"text":"From push"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText1","isRegex":false},"expectation":"toBeVisible","params":[1]}}
+< Expect "HText1" to be visible by 100%
++ {"text":"HText1","expected":1}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText1","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "HText1" to be visible
++ {"text":"HText1"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText6","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "HText6" to be visible
++ {"text":"HText6"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText6","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "HText6" not to be visible
++ {"text":"HText6"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText7","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "HText7" to be visible
++ {"text":"HText7"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText7","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "HText7" not to be visible
++ {"text":"HText7"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText8","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "HText8" to be visible
++ {"text":"HText8"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"HText8","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "HText8" not to be visible
++ {"text":"HText8"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Hello!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Hello!!!" to be visible
++ {"text":"Hello!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"I contain some text","isRegex":false},"expectation":"toHaveId","params":["main-text"]}}
+< Expect "I contain some text" to have id main-text
++ {"text":"I contain some text","expected":"main-text"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"ID Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "ID Working!!!" to be visible
++ {"text":"ID Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Immediate Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Immediate Working!!!" to be visible
++ {"text":"Immediate Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Interval Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Interval Ignored!!!" to be visible
++ {"text":"Interval Ignored!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Interval Skipped-Over!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Interval Skipped-Over!!!" to be visible
++ {"text":"Interval Skipped-Over!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Label Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Label Working!!!" to be visible
++ {"text":"Label Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"expectation":"toBeVisible","timeout":4000}}
+< Expect "Long Network Re…est Working!!!" to be visible
++ {"text":"Long Network Request Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Long Network Re…est Working!!!" to be visible
++ {"text":"Long Network Request Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Network Request Working!!!","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Long Network Re…est Working!!!" not to be visible
++ {"text":"Long Network Request Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press With Duration Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Long Press With…ion Working!!!" to be visible
++ {"text":"Long Press With Duration Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Long Press Working!!!" to be visible
++ {"text":"Long Press Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press on Top Left Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Long Press on T…eft Working!!!" to be visible
++ {"text":"Long Press on Top Left Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Press on Top Left Working!!!","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Long Press on T…eft Working!!!" not to be visible
++ {"text":"Long Press on Top Left Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Long Timeout Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Long Timeout Ignored!!!" to be visible
++ {"text":"Long Timeout Ignored!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"My Alert Msg","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "My Alert Msg" to be visible
++ {"text":"My Alert Msg"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Obscured by keyboard","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Obscured by keyboard" to be visible
++ {"text":"Obscured by keyboard"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Obscured by keyboard","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Obscured by keyboard" not to be visible
++ {"text":"Obscured by keyboard"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Product","isRegex":false},"atIndex":2,"expectation":"toHaveId","params":["ProductId002"]}}
+< Expect "Product" to have id ProductId002
++ {"text":"Product","expected":"ProductId002"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Sanity","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Sanity" to be visible
++ {"text":"Sanity"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Say Hello","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Say Hello" to be visible
++ {"text":"Say Hello"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Say World","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Say World" to be visible
++ {"text":"Say World"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Custom Duration Pressed","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Screen Long Cus…ration Pressed" to be visible
++ {"text":"Screen Long Custom Duration Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Custom Duration Pressed","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Screen Long Cus…ration Pressed" not to be visible
++ {"text":"Screen Long Custom Duration Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Long Pressed","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Screen Long Pressed" to be visible
++ {"text":"Screen Long Pressed"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Screen Tapped","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Screen Tapped" to be visible
++ {"text":"Screen Tapped"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Shaken, not stirred","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Shaken, not stirred" to be visible
++ {"text":"Shaken, not stirred"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Network Request Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Short Network R…est Working!!!" to be visible
++ {"text":"Short Network Request Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Timeout Ignored!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Short Timeout Ignored!!!" to be visible
++ {"text":"Short Timeout Ignored!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Short Timeout Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Short Timeout Working!!!" to be visible
++ {"text":"Short Timeout Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Tap Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Tap Working!!!" to be visible
++ {"text":"Tap Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"expectation":"toBeVisible","params":[1]}}
+< Expect "Text1" to be visible by 100%
++ {"text":"Text1","expected":1}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Text1" to be visible
++ {"text":"Text1"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Text1" not to be visible
++ {"text":"Text1"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text1000","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Text1000" not to be visible
++ {"text":"Text1000"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text12","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Text12" to be visible
++ {"text":"Text12"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text12","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Text12" not to be visible
++ {"text":"Text12"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text16","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible","params":[80]}}
+< Expect "Text16" not to be visible by 8000%
++ {"text":"Text16","expected":80}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text4","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Text4" to be visible
++ {"text":"Text4"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text4","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Text4" not to be visible
++ {"text":"Text4"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Text5" to be visible
++ {"text":"Text5"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Text5","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "Text5" not to be visible
++ {"text":"Text5"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Traits Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Traits Working!!!" to be visible
++ {"text":"Traits Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Type Working 123 אֱבּג абв!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Type Working 123 אֱבּג абв!!!" to be visible
++ {"text":"Type Working 123 אֱבּג абв!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Welcome","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Welcome" to be visible
++ {"text":"Welcome"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"World!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "World!!!" to be visible
++ {"text":"World!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"Zero Timeout Working!!!","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "Zero Timeout Working!!!" to be visible
++ {"text":"Zero Timeout Working!!!"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"com.test.itemId","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "com.test.itemId" to be visible
++ {"text":"com.test.itemId"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"detoxtesturlscheme://such-string?arg1=first&arg2=second","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "detoxtesturlsch…st&arg2=second" to be visible
++ {"text":"detoxtesturlscheme://such-string?arg1=first&arg2=second"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"detoxtesturlscheme://such-string?arg1=first&arg2=second","isRegex":false},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect "detoxtesturlsch…st&arg2=second" not to be visible
++ {"text":"detoxtesturlscheme://such-string?arg1=first&arg2=second"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"https://my.deeplink.dtx","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "https://my.deeplink.dtx" to be visible
++ {"text":"https://my.deeplink.dtx"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"text","value":"this is a new native root","isRegex":false},"expectation":"toBeVisible"}}
+< Expect "this is a new native root" to be visible
++ {"text":"this is a new native root"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"type","value":"RCTImageView"},"expectation":"toBeVisible"}}
+< Expect [type] = RCTImageView to be visible
++ {"type":"RCTImageView"}
+
+> {"type":"invoke","params":{"type":"expectation","predicate":{"type":"type","value":"RCTImageView"},"modifiers":["not"],"expectation":"toBeVisible"}}
+< Expect [type] = RCTImageView not to be visible
++ {"type":"RCTImageView"}
+
+> {"type":"invoke","params":{"type":"webAction","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"body"},"webAction":"getTitle"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"bottomParagraph"},"webAction":"scrollToView"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"clearText"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"focus"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"moveCursorToEnd"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"replaceText","params":["Tester"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"selectAllText"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["Tes"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["Test"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["er"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["r"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"contentEditable"},"webAction":"typeText","params":["te"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"clearText"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"focus"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"moveCursorToEnd"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"replaceText","params":["Tester"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"runScript","params":["el => {\\n              el.type = 'email';\\n            }"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"selectAllText"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["0123456789 ABCDEF"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Temp"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Test"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["Tester"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"fname"},"webAction":"typeText","params":["er"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"getText"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { el.textContent = \\"Changed\\"; throw new Error(\\"Error\\"); }"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { el.textContent = \\"Changed\\"; }"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["(el) => { return el.textContent; }"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScript","params":["el => {\\n          el.textContent = \\"Changed\\";\\n        }"]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScriptWithArgs","params":["(el, text) => { el.textContent = text; }",["Changed"]]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"pageHeadline"},"webAction":"runScriptWithArgs","params":["(el, text) => {\\n          el.textContent = text;\\n        }",["Changed"]]}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"submit"},"webAction":"tap"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"id","value":"w3link"},"webAction":"tap"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"tag","value":"body"},"webAction":"getCurrentUrl"}}
+
+> {"type":"invoke","params":{"type":"webAction","webPredicate":{"type":"tag","value":"body"},"webAction":"getTitle"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":0,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":1,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"atIndex":2,"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"id","value":"message"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"id","value":"message"},"webExpectation":"toHaveText","params":["This is a dummy webview."]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"h1"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","predicate":{"type":"id","value":"webView","isRegex":false},"webPredicate":{"type":"tag","value":"h1"},"webModifiers":["not"],"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"class","value":"specialParagraph"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"css","value":".specialParagraph"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"href","value":"https://www.w3schools.com"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"hrefContains","value":"w3schools"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":[""]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":["Name: Tester"]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"contentEditable"},"webExpectation":"toHaveText","params":["Tester"]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":[""]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":["0123456789"]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"fname"},"webExpectation":"toHaveText","params":["Tester"]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"nonExistentElement"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"nonExistentElement"},"webModifiers":["not"],"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"pageHeadline"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"id","value":"pageHeadline"},"webExpectation":"toHaveText","params":["Changed"]}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"label","value":"first-webview"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"name","value":"fname"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"body"},"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":0,"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":100,"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"tag","value":"p"},"webAtIndex":100,"webModifiers":["not"],"webExpectation":"toExist"}}
+
+> {"type":"invoke","params":{"type":"webExpectation","webPredicate":{"type":"xpath","value":"//p[@class=\\"specialParagraph\\"]"},"webExpectation":"toExist"}}
+
+> {"type":"isReady","params":{}}
+
+> {"type":"loginSuccess","params":{"testerConnected":true,"appConnected":true}}
+
+> {"type":"reactNativeReload","params":{}}
+
+> {"type":"setOrientation","params":{"orientation":"landscape"}}
+
+> {"type":"setOrientation","params":{"orientation":"portrait"}}
+
+> {"type":"setSyncSettings","params":{"blacklistURLs":[".*localhost.*"]}}
+
+> {"type":"setSyncSettings","params":{"enabled":false}}
+
+> {"type":"setSyncSettings","params":{"enabled":true}}
+
+> {"type":"shakeDevice","params":{}}
+
+> {"type":"testerDisconnected"}
+
+> {"type":"waitForActive","params":{}}
+
+> {"type":"waitForBackground","params":{}}
+"
+`;

--- a/src/steps/description-maker/ios/detox-payload.ts
+++ b/src/steps/description-maker/ios/detox-payload.ts
@@ -1,0 +1,171 @@
+export type DetoxMessage = InvokeMessage | DeliverPayloadMessage;
+
+//#region Predicates
+export type PredicateType =
+  | 'id'
+  | 'text'
+  | 'label'
+  | 'traits'
+  | 'accessibilityLabel'
+  | 'accessibilityIdentifier';
+
+export interface Predicate {
+  type: PredicateType | 'and';
+  value: string | string[] | number | boolean;
+  isRegex?: boolean;
+  atIndex?: number;
+  predicates?: Predicate[];
+  ancestor?: Predicate;
+  descendant?: Predicate;
+  targetElement?: {
+    predicate: Predicate;
+  };
+}
+//#endregion Predicates
+
+//#region Detox Base Types
+export type DetoxAction =
+  | 'tap'
+  | 'longPress'
+  | 'scroll'
+  | 'scrollTo'
+  | 'replaceText'
+  | 'typeText'
+  | 'accessibilityAction'
+  | 'setDatePickerDate';
+
+export type DetoxExpectation =
+  | 'toBeVisible'
+  | 'toExist'
+  | 'toHaveText'
+  | 'toHaveLabel'
+  | 'toBeEnabled'
+  | 'toBeFocused'
+  | 'toBeDisabled';
+
+export type ExpectationModifier = 'not';
+
+export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+export type ScrollEdge = 'top' | 'bottom' | 'left' | 'right';
+//#endregion Detox Base Types
+
+//#region Base Invocation
+interface BaseInvocation {
+  predicate: Predicate;
+  timeout?: number;
+  atIndex?: number;
+  params?: readonly unknown[];
+}
+//#endregion Base Invocation
+
+//#region Invocations
+export interface ExpectationInvocation extends BaseInvocation {
+  type: 'expectation';
+  expectation: DetoxExpectation;
+  modifiers?: ExpectationModifier[];
+}
+
+export interface BaseActionInvocation extends BaseInvocation {
+  type: 'action';
+  action: DetoxAction;
+  while?: ExpectationInvocation;
+}
+//#endregion Invocations
+
+//#region Action Invocations
+export interface TapAction extends BaseActionInvocation {
+  action: 'tap';
+}
+
+export interface LongPressAction extends BaseActionInvocation {
+  action: 'longPress';
+  params: LongPressParams;
+}
+
+export interface ScrollAction extends BaseActionInvocation {
+  action: 'scroll';
+  params: ScrollParams;
+}
+
+export interface ScrollToAction extends BaseActionInvocation {
+  action: 'scrollTo';
+  params: ScrollToParams;
+}
+
+export interface ReplaceTextAction extends BaseActionInvocation {
+  action: 'replaceText';
+  params: TextParams;
+}
+
+export interface TypeTextAction extends BaseActionInvocation {
+  action: 'typeText';
+  params: TextParams;
+}
+
+export interface AccessibilityAction extends BaseActionInvocation {
+  action: 'accessibilityAction';
+  params: AccessibilityActionParams;
+}
+
+export interface SetDatePickerAction extends BaseActionInvocation {
+  action: 'setDatePickerDate';
+  params: DatePickerParams;
+}
+//#endregion Action Invocations
+
+//#region Invocation Union Types
+export type ActionInvocation =
+  | TapAction
+  | LongPressAction
+  | ScrollAction
+  | ScrollToAction
+  | ReplaceTextAction
+  | TypeTextAction
+  | AccessibilityAction
+  | SetDatePickerAction;
+
+export type Invocation = ActionInvocation | ExpectationInvocation;
+//#endregion Invocation Union Types
+
+//#region Action Params
+export type ScrollParams = readonly [distance: number, direction: ScrollDirection];
+export type ScrollToParams = readonly [
+  edge: ScrollEdge,
+  normalizedX?: number,
+  normalizedY?: number,
+];
+export type LongPressParams = readonly [duration: number];
+export type TextParams = readonly [text: string];
+export type DatePickerParams = readonly [date: string, format?: string];
+export type AccessibilityActionParams = readonly [action: string];
+
+export type ActionParams =
+  | ScrollParams
+  | ScrollToParams
+  | LongPressParams
+  | TextParams
+  | DatePickerParams
+  | AccessibilityActionParams;
+//#endregion Action Params
+
+//#region Messages
+export interface InvokeMessage {
+  type: 'invoke';
+  params: Invocation;
+}
+
+export interface DeliverPayloadMessage {
+  type: 'deliverPayload';
+  params: DeliverPayloadParams;
+}
+
+export interface DeliverPayloadParams {
+  url: string;
+  delayPayload?: boolean;
+  viewHierarchyURL?: string;
+  detoxUserActivityDataURL?: string;
+  detoxUserNotificationDataURL?: string;
+  newInstance?: boolean;
+  shouldInjectTestIds?: boolean;
+}
+//#endregion Messages

--- a/src/steps/description-maker/ios/formatters/action-formatters.ts
+++ b/src/steps/description-maker/ios/formatters/action-formatters.ts
@@ -1,0 +1,53 @@
+import type { StepDescription } from '../../types';
+import type { ActionInvocation } from '../detox-payload';
+import { formatWhileCondition } from './expectation-formatters';
+import { formatPredicate as p } from './predicate-formatters';
+import { concat, msg } from './utils';
+
+type ActionFormatter<T extends ActionInvocation> = (action: T) => StepDescription;
+
+type ActionFormatterMap = Partial<{
+  [K in ActionInvocation['action']]: ActionFormatter<Extract<ActionInvocation, { action: K }>>;
+}>;
+
+const actionFormatters: ActionFormatterMap = {
+  tap: ({ predicate }) => concat('Tap', p(predicate)),
+
+  longPress: ({ predicate, params: [duration] }) =>
+    concat(msg('Long press', { duration }), p(predicate)),
+
+  scroll: ({ predicate, params: [distance, direction], while: whileCondition }) => {
+    return concat(
+      msg(`Scroll ${direction} on`, { direction, distance }),
+      p(predicate),
+      formatWhileCondition(whileCondition),
+    );
+  },
+
+  scrollTo: ({ predicate, params: [edge, normalizedX, normalizedY] }) =>
+    concat(
+      msg(`Scroll to ${edge}`, {
+        edge,
+        ...(normalizedX !== undefined && { x: normalizedX, y: normalizedY }),
+      }),
+      'on',
+      p(predicate),
+    ),
+
+  replaceText: ({ predicate, params: [text] }) =>
+    concat(msg('Replace text in', { text }), p(predicate)),
+
+  typeText: ({ predicate, params: [text] }) => concat(msg('Type text in', { text }), p(predicate)),
+
+  accessibilityAction: ({ predicate, params: [action] }) =>
+    concat(msg(`Activate a11y "${action}" on`, { action }), p(predicate)),
+
+  setDatePickerDate: ({ predicate, params: [date, format] }) =>
+    concat('Set date picker', p(predicate), msg(`${date}`, { date, format })),
+};
+
+// Main entry point that routes to the correct formatter based on action type
+export const formatAction = (action: ActionInvocation): StepDescription | null => {
+  const formatter = actionFormatters[action.action];
+  return formatter ? formatter(action as any) : null;
+};

--- a/src/steps/description-maker/ios/formatters/expectation-formatters.ts
+++ b/src/steps/description-maker/ios/formatters/expectation-formatters.ts
@@ -1,0 +1,48 @@
+import type { StepDescription } from '../../types';
+import type { ExpectationInvocation } from '../detox-payload';
+import { formatPredicate } from './predicate-formatters';
+import { concat, msg, percent, truncate } from './utils';
+
+const formatExpectationVerb = (invocation: ExpectationInvocation): string => {
+  const hasNot = invocation.modifiers?.includes('not');
+  const verb = invocation.expectation
+    .replace(/([A-Z])/g, ' $1')
+    .toLowerCase()
+    .trim();
+  return `${hasNot ? 'not ' : ''}${verb}`;
+};
+
+const formatExpectationParams = (invocation: ExpectationInvocation): StepDescription | null => {
+  const [expected] = invocation.params || [];
+
+  switch (invocation.expectation) {
+    case 'toBeVisible': {
+      return typeof expected === 'number' ? msg(`by ${percent(expected)}`, { expected }) : null;
+    }
+
+    default: {
+      return expected == null ? null : msg(`${truncate(expected)}`, { expected });
+    }
+  }
+};
+
+export const formatWhileCondition = (
+  expectation?: ExpectationInvocation,
+): StepDescription | null => {
+  return expectation
+    ? concat(
+        'while waiting for',
+        formatPredicate(expectation.predicate, 'while'),
+        formatExpectationVerb(expectation),
+      )
+    : null;
+};
+
+export const formatExpectation = (invocation: ExpectationInvocation): StepDescription => {
+  return concat(
+    'Expect',
+    formatPredicate(invocation.predicate),
+    formatExpectationVerb(invocation),
+    formatExpectationParams(invocation),
+  );
+};

--- a/src/steps/description-maker/ios/formatters/index.ts
+++ b/src/steps/description-maker/ios/formatters/index.ts
@@ -1,0 +1,4 @@
+export * from './action-formatters';
+export * from './expectation-formatters';
+export * from './message-formatters';
+export * from './predicate-formatters';

--- a/src/steps/description-maker/ios/formatters/message-formatters.ts
+++ b/src/steps/description-maker/ios/formatters/message-formatters.ts
@@ -1,0 +1,39 @@
+import type { StepDescription } from '../../types';
+import type { DetoxMessage, Invocation } from '../detox-payload';
+import { formatAction } from './action-formatters';
+import { formatExpectation } from './expectation-formatters';
+import { msg } from './utils';
+
+type MessageFormatter<T extends DetoxMessage> = (message: T) => StepDescription | null;
+
+type MessageFormatterMap = {
+  [K in DetoxMessage['type']]: MessageFormatter<Extract<DetoxMessage, { type: K }>>;
+};
+
+const messageFormatters: MessageFormatterMap = {
+  invoke: (message) => {
+    const invocation = message.params;
+    return formatInvocation(invocation);
+  },
+  deliverPayload: ({ params: { url, delayPayload } }) =>
+    msg('Deliver payload', { url, delayPayload }),
+};
+
+const formatInvocation = (invocation: Invocation): StepDescription | null => {
+  switch (invocation.type) {
+    case 'action': {
+      return formatAction(invocation);
+    }
+    case 'expectation': {
+      return formatExpectation(invocation);
+    }
+    default: {
+      return null;
+    }
+  }
+};
+
+export const formatMessage = (message: DetoxMessage): StepDescription | null => {
+  const formatter = messageFormatters[message.type];
+  return formatter ? formatter(message as any) : null;
+};

--- a/src/steps/description-maker/ios/formatters/predicate-formatters.ts
+++ b/src/steps/description-maker/ios/formatters/predicate-formatters.ts
@@ -1,0 +1,88 @@
+import type { StepArgs, StepDescription } from '../../types';
+import type { Predicate } from '../detox-payload';
+import { concat, truncate } from './utils';
+
+function join(a: string, b: string): string {
+  return a && b ? `${a}_${b}` : a || b;
+}
+
+function formatBasePredicate(predicate: Predicate, prefix = ''): StepDescription {
+  const { type, value, atIndex, isRegex } = predicate;
+  const _ = (name: string) => join(prefix, name);
+
+  const index$ = atIndex == null ? '' : `[${atIndex}]`;
+  const args: StepArgs = { [_(type)]: value };
+  if (index$) {
+    args[_('index')] = atIndex;
+  }
+
+  const value$ = truncate(value);
+
+  // Handle regex predicates
+  if (isRegex) {
+    return {
+      message: `[${type}] ~ ${value$}` + index$,
+      args,
+    };
+  }
+
+  // Handle text predicates
+  if (type === 'label' || type === 'accessibilityLabel' || type === 'text') {
+    return {
+      message: `"${value$}"${index$ ? ' ' : ''}${index$}`,
+      args,
+    };
+  }
+
+  // Handle traits predicates
+  if (type === 'traits') {
+    return {
+      message: `[${value$}]${index$}`,
+      args,
+    };
+  }
+
+  if (type === 'id') {
+    return {
+      message: `#${value$}${index$}`,
+      args,
+    };
+  }
+
+  return {
+    message: `[${type}] = ${value$}${index$}`,
+    args,
+  };
+}
+
+export const formatPredicate = (predicate: Predicate, prefix = ''): StepDescription => {
+  const { predicates, ancestor, descendant } = predicate;
+
+  // Handle compound predicates
+  if (predicates) {
+    const formattedPredicates = predicates.map((p) => formatPredicate(p));
+    return {
+      message: `(${formattedPredicates.map((p) => p.message).join(' AND ')})`,
+      args: formattedPredicates.reduce((acc, p) => ({ ...acc, ...p.args }), {}),
+    };
+  }
+
+  // Handle ancestor/descendant relationships
+  if (ancestor) {
+    return concat(
+      formatBasePredicate(predicate),
+      'inside',
+      formatPredicate(ancestor, join(prefix, 'ancestor')),
+    );
+  }
+
+  if (descendant) {
+    return concat(
+      formatBasePredicate(predicate),
+      'containing',
+      formatPredicate(descendant, join(prefix, 'descendant')),
+    );
+  }
+
+  return formatBasePredicate(predicate, prefix);
+};

--- a/src/steps/description-maker/ios/formatters/utils.test.ts
+++ b/src/steps/description-maker/ios/formatters/utils.test.ts
@@ -1,0 +1,72 @@
+import { percent, truncate } from './utils';
+
+describe('percent', () => {
+  it('should return empty string for abnormal values', () => {
+    expect(percent('')).toBe('');
+    expect(percent(null)).toBe('');
+    expect(percent()).toBe('');
+    expect(percent(Number.NaN)).toBe('');
+    expect(percent(Number.POSITIVE_INFINITY)).toBe('');
+    expect(percent([])).toBe('');
+    expect(percent({})).toBe('');
+    expect(percent('')).toBe('');
+  });
+
+  it('should convert valid numbers to strings', () => {
+    expect(percent(0.75)).toBe('75%');
+    expect(percent(1)).toBe('100%');
+    expect(percent(0)).toBe('0%');
+    expect(percent(0.33)).toBe('33%');
+  });
+
+  it('should handle string numbers', () => {
+    expect(percent('0.5')).toBe('50%');
+    expect(percent('0')).toBe('0%');
+    expect(percent('1')).toBe('100%');
+  });
+});
+
+describe('truncate', () => {
+  it('should return empty string for falsy values', () => {
+    expect(truncate('')).toBe('');
+    expect(truncate(null)).toBe('');
+    expect(truncate()).toBe('');
+  });
+
+  it('should not truncate strings shorter than MAX_LENGTH', () => {
+    const shortString = 'Hello, World!';
+    expect(truncate(shortString)).toBe(shortString);
+  });
+
+  it('should truncate long string with ellipsis in the middle', () => {
+    const longString = '12345678901234567890123456789012345'; // 35 chars
+    const result = truncate(longString);
+
+    expect(result.length).toBe(30); // MAX_LENGTH
+    expect(result).toBe('123456789012345…23456789012345');
+  });
+
+  it('should handle non-string values', () => {
+    const number = 123_456_789_012_345;
+    expect(truncate(number)).toBe('123456789012345');
+  });
+
+  it('should handle string exactly at MAX_LENGTH', () => {
+    const exactString = '0'.repeat(30);
+    expect(truncate(exactString)).toBe(exactString);
+  });
+
+  it('should split characters evenly with odd MAX_LENGTH - 1', () => {
+    // MAX_LENGTH (30) - 1 for ellipsis = 29 chars to distribute
+    // Should be split as 15 chars front, 14 chars back
+    const longString = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789';
+    const result = truncate(longString);
+
+    const frontPart = result.split('…')[0];
+    const backPart = result.split('…')[1];
+
+    expect(frontPart.length).toBe(15);
+    expect(backPart.length).toBe(14);
+    expect(result).toBe('ABCDEFGHIJKLMNO…VWXYZ123456789');
+  });
+});

--- a/src/steps/description-maker/ios/formatters/utils.ts
+++ b/src/steps/description-maker/ios/formatters/utils.ts
@@ -1,0 +1,65 @@
+import type { StepDescription, StepArgs } from '../../types';
+
+export function concat(...results: (StepDescription | string | null)[]): StepDescription {
+  return {
+    message: results.map(stringify).reduce(join, ''),
+    args: results.map(getArgs).reduce(mergeArgs),
+  };
+}
+
+export function msg(message: string, args: StepArgs): StepDescription {
+  return {
+    message,
+    args: omitEmpty(args),
+  };
+}
+
+export function percent(value?: unknown): string {
+  const num =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value
+        ? Number(value)
+        : Number.NaN;
+
+  return Number.isFinite(num) ? (num * 100).toFixed(0) + '%' : '';
+}
+
+export function truncate(value?: unknown, maxLength = 30): string {
+  if (!value) return '';
+
+  const str = typeof value === 'string' ? value : String(value);
+  if (str.length <= maxLength) return str;
+
+  const charsToShow = maxLength - 1; // -1 for the ellipsis
+  const frontChars = Math.ceil(charsToShow / 2);
+  const backChars = Math.floor(charsToShow / 2);
+  const backStart = str.length - backChars;
+
+  return str.slice(0, Math.max(0, frontChars)) + '…' + str.slice(Math.max(0, backStart));
+}
+
+function stringify(desc: StepDescription | string | null | undefined): string | null {
+  if (!desc) return null;
+  return typeof desc === 'string' ? desc : desc?.message;
+}
+
+function join(acc: string, desc: string | null): string {
+  return acc && desc ? `${acc} ${desc}` : (desc ?? acc);
+}
+
+function omitEmpty(args: StepArgs): StepArgs {
+  return args ? Object.fromEntries(Object.entries(args).filter(isNotNullish)) : args;
+}
+
+function isNotNullish([_key, value]: [string, unknown]): boolean {
+  return value != null;
+}
+
+function getArgs(r: StepDescription | string | null): StepArgs {
+  return r !== null && typeof r === 'object' ? r.args : null;
+}
+
+function mergeArgs(acc: StepArgs, r: StepArgs): StepArgs {
+  return r == null ? acc : { ...acc, ...r };
+}

--- a/src/steps/description-maker/ios/index.ts
+++ b/src/steps/description-maker/ios/index.ts
@@ -1,0 +1,1 @@
+export * from './ios-description-maker';

--- a/src/steps/description-maker/ios/ios-description-maker.test.ts
+++ b/src/steps/description-maker/ios/ios-description-maker.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import { iosDescriptionMaker } from './ios-description-maker';
+
+const loadFixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, '__fixtures__', `${name}.json`), 'utf8'));
+
+const formatPayloadAndDescription = (payload: any) => {
+  const lines: string[] = [];
+
+  // Always show the payload
+  lines.push(`> ${JSON.stringify(payload)}`);
+
+  // If we have a description, show message and args
+  const description = iosDescriptionMaker(payload);
+  if (description) {
+    lines.push(`< ${description.message}`, `+ ${JSON.stringify(description.args)}`);
+  }
+
+  // Add empty line as separator
+  lines.push('');
+
+  return lines.join('\n');
+};
+
+const parseJsonLine = (line: string) => {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+};
+
+describe('iOS description maker', () => {
+  test.each([
+    ['tap-basic-button', 'Tap #SimpleButton', { id: 'SimpleButton' }],
+    ['tap-indexed-button', 'Tap #IndexedButton[1]', { id: 'IndexedButton', index: 1 }],
+    ['long-press-button', 'Long press #LongPressButton', { duration: 1000, id: 'LongPressButton' }],
+    [
+      'scroll-vertical',
+      'Scroll down on #ScrollView',
+      { direction: 'down', distance: 100, id: 'ScrollView' },
+    ],
+    ['type-text-input', 'Type text in #TextInput', { id: 'TextInput', text: 'Hello World' }],
+    [
+      'scroll-to-with-coordinates',
+      'Scroll to bottom on #ScrollView161',
+      { edge: 'bottom', x: 0.2, y: 0.4, id: 'ScrollView161' },
+    ],
+    [
+      'scroll-to-without-coordinates',
+      'Scroll to top on #ScrollView161',
+      { edge: 'top', id: 'ScrollView161' },
+    ],
+    ['tap-compound-and', 'Tap (#button AND "Click me")', { id: 'button', label: 'Click me' }],
+    ['tap-with-traits', 'Tap [button,selected]', { traits: ['button', 'selected'] }],
+    [
+      'tap-with-ancestor',
+      'Tap #childButton inside #parentView',
+      { id: 'childButton', ancestor_id: 'parentView' },
+    ],
+    [
+      'scroll-with-while',
+      'Scroll down on #ScrollView while waiting for "Text5" to be visible',
+      { direction: 'down', distance: 50, id: 'ScrollView', while_text: 'Text5' },
+    ],
+  ])('should handle %s selector', (fixture, message, args) => {
+    const description = iosDescriptionMaker(loadFixture(fixture));
+    expect(description).toEqual({ message, args });
+  });
+
+  test('should process everything.jsonl fixture', () => {
+    // Read and parse the JSONL file
+    const fileContent = fs.readFileSync(
+      path.join(__dirname, '__fixtures__', 'everything.jsonl'),
+      'utf8',
+    );
+    const lines = fileContent.split('\n').map(parseJsonLine).filter(Boolean);
+
+    // Format each payload and join them together
+    const results = lines.map(formatPayloadAndDescription).join('\n');
+
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/src/steps/description-maker/ios/ios-description-maker.ts
+++ b/src/steps/description-maker/ios/ios-description-maker.ts
@@ -1,0 +1,8 @@
+import type { StepDescriptionMaker } from '../types';
+import type { DetoxMessage } from './detox-payload';
+import { formatMessage } from './formatters';
+
+export const iosDescriptionMaker: StepDescriptionMaker = (payload: unknown) => {
+  const message = payload as DetoxMessage;
+  return formatMessage(message);
+};

--- a/src/steps/description-maker/types.ts
+++ b/src/steps/description-maker/types.ts
@@ -1,0 +1,8 @@
+export type StepDescription = {
+  message: string;
+  args: StepArgs;
+};
+
+export type StepArgs = Record<string, any> | null | undefined;
+
+export type StepDescriptionMaker = (payload: unknown) => StepDescription | null;

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -1,0 +1,1 @@
+export { wrapWithSteps } from './wrapWithSteps';

--- a/src/steps/wrapWithSteps.ts
+++ b/src/steps/wrapWithSteps.ts
@@ -1,0 +1,39 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { AllureRuntime } from 'jest-allure2-reporter/api';
+import { iosDescriptionMaker } from './description-maker';
+
+export function wrapWithSteps(detox: typeof import('detox'), worker: any, allure: AllureRuntime) {
+  const { device } = detox;
+
+  device.launchApp = allure.createStep('Launch app', [], device.launchApp);
+  device.relaunchApp = allure.createStep('Relaunch app', [], device.relaunchApp);
+  device.terminateApp = allure.createStep('Terminate app', [], device.terminateApp);
+  device.openURL = allure.createStep('Open URL', [], device.openURL);
+  device.reloadReactNative = allure.createStep(
+    'Reload React Native bundle',
+    [],
+    device.reloadReactNative,
+  );
+
+  device.sendToHome = allure.createStep('Send app to background', [], device.sendToHome);
+  device.setOrientation = allure.createStep('Set orientation', [], device.setOrientation);
+
+  device.matchFace = allure.createStep('Match face', [], device.matchFace);
+  device.unmatchFace = allure.createStep('Unmatch face', [], device.unmatchFace);
+  device.matchFinger = allure.createStep('Match finger', [], device.matchFinger);
+  device.unmatchFinger = allure.createStep('Unmatch finger', [], device.unmatchFinger);
+
+  if (device.getPlatform() === 'ios') {
+    const ws = worker._client._asyncWebSocket;
+    const send = ws.send.bind(ws);
+    ws.send = async (...args: any[]) => {
+      const desc = iosDescriptionMaker(args[0]);
+      return desc
+        ? allure.step(desc.message, () => {
+            if (desc.args) allure.parameters(desc.args);
+            return send(...args);
+          })
+        : send(...args);
+    };
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "importHelpers": true,
-    "importsNotUsedAsValues": "error",
     "ignoreDeprecations": "5.0",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Part of:

- #4

So, when enabled via `{ useSteps: true }`, e.g.:

```
    'testEnvironmentOptions': {
      'eventListeners': [
        'jest-metadata/environment-listener',
        'jest-allure2-reporter/environment-listener',
        ['detox-allure2-adapter', { useSteps: true }],
      ]
    },
```

You will get this alpha-stage functionality for iOS — every action/expectation gets annotated.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/c0c671e2-e020-4f0a-a83f-c0b5dc37a375" />

The feature is planned to be available by default but right now it is under internal testing.