### PR TITLE
fix(ios): save statuses of steps

### DIFF
--- a/src/steps/wrapWithSteps.ts
+++ b/src/steps/wrapWithSteps.ts
@@ -25,13 +25,19 @@ export function wrapWithSteps(detox: typeof import('detox'), worker: any, allure
 
   if (device.getPlatform() === 'ios') {
     const ws = worker._client._asyncWebSocket;
-    const send = ws.send.bind(ws);
+    const send = ws.send.bind(ws) as (...args: any[]) => Promise<{ type?: string }>;
     ws.send = async (...args: any[]) => {
       const desc = iosDescriptionMaker(args[0]);
       return desc
         ? allure.step(desc.message, () => {
             if (desc.args) allure.parameters(desc.args);
-            return send(...args);
+            return send(...args).then((result: { type?: string }) => {
+              if (result?.type === 'testFailed') {
+                allure.status('failed');
+              }
+
+              return result;
+            });
           })
         : send(...args);
     };


### PR DESCRIPTION
Failed steps were not marked with red color in Allure reports, so I decided to fix this for better clarity, e.g.:

![image](https://github.com/user-attachments/assets/bb2e06e6-da80-4cc8-ae51-4c663774639e)
