### PR TITLE
fix: leaner status details

### DIFF
--- a/src/preset/allure.ts
+++ b/src/preset/allure.ts
@@ -5,6 +5,7 @@ import type {
   ReporterOptions,
   TestCaseCustomizer,
   TestCaseExtractorContext,
+  StatusDetails,
 } from 'jest-allure2-reporter';
 
 const historyId: TestCaseCustomizer['historyId'] = ({ value }): string => {
@@ -32,6 +33,29 @@ const device: KeyedParameterCustomizer<unknown> = (): string | undefined => {
   }
 };
 
+const statusDetails: TestCaseCustomizer['statusDetails'] = ({ value }) => {
+  const maybeValue = value as StatusDetails | undefined;
+  const message = maybeValue?.message;
+  const trace = maybeValue?.trace;
+
+  if (typeof message === 'string' && (!trace || typeof trace === 'string')) {
+    const lines = message.split('\n');
+    if (lines.length > 1) {
+      const [first, ...rest] = message.split('\n');
+      if (trace) {
+        rest.push(trace);
+      }
+
+      return {
+        message: first,
+        trace: rest.join('\n').trimStart(),
+      };
+    }
+  }
+
+  return value;
+};
+
 const status: TestCaseCustomizer<TestCaseExtractorContext>['status'] = ({
   testCase: { failureMessages },
   value,
@@ -51,12 +75,14 @@ const options: ReporterOptions = {
   testCase: {
     historyId,
     status,
+    statusDetails,
     parameters: {
       device,
     },
   },
   testFile: {
     historyId,
+    statusDetails,
     parameters: {
       device,
     },


### PR DESCRIPTION
This pull request includes changes to the `src/preset/allure.ts` file to enhance the handling of status details in test cases. 

![image](https://github.com/user-attachments/assets/201d99c3-3d73-4cf0-b220-78985140fbdd)

Basically we make sure that error message takes 1 line, and the rest is in the details.

This should make it more pleasant to browse the categories.