### PR TITLE
fix: better screenshots and logs timing

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -15,7 +15,7 @@ import { LogBuffer } from './logs';
 import { ScreenshotHelper } from './screenshots';
 import { wrapWithSteps } from './steps';
 import type { DetoxAllure2AdapterOptions } from './types';
-import { ArtifactsWrapper, DeviceWrapper } from './utils';
+import { DeviceWrapper, WorkerWrapper } from './utils';
 
 export const listener: EnvironmentListenerFn = (
   { testEvents },
@@ -42,8 +42,8 @@ export const listener: EnvironmentListenerFn = (
         inferMimeType = context.inferMimeType;
       });
 
-      const artifactsWrapper = new ArtifactsWrapper(worker);
-      artifactsWrapper.artifactsManager.on('trackArtifact', onTrackArtifact);
+      const workerWrapper = new WorkerWrapper(worker);
+      workerWrapper.artifactsManager.on('trackArtifact', onTrackArtifact);
 
       const device = new DeviceWrapper(detox.device);
       if (deviceLogs) {
@@ -52,6 +52,9 @@ export const listener: EnvironmentListenerFn = (
           options: deviceLogs,
           onError,
         });
+
+        workerWrapper.eventEmitter.on('launchApp', ({ pid }) => logs?.setPid(pid));
+        workerWrapper.eventEmitter.on('terminateApp', () => logs?.setPid(Number.NaN));
       }
 
       if (deviceScreenshots) {
@@ -82,9 +85,15 @@ export const listener: EnvironmentListenerFn = (
       await screenshots?.attachSuccess(allure);
       logs?.attachAfterSuccess(allure);
     })
-    .on('test_done', async ({ event }) => {
-      await screenshots?.attach(allure, event.test.failing);
-      logs?.attachAfter(allure, event.test.failing);
+    .on('test_fn_failure', async () => {
+      await screenshots?.attachFailure(allure);
+      logs?.attachAfterFailure(allure);
+    })
+    .on('test_fn_success', async () => {
+      await screenshots?.attachSuccess(allure);
+      logs?.attachAfterSuccess(allure);
+    })
+    .on('test_done', async () => {
       $test = undefined;
     })
     .on('teardown', flushArtifacts, -1)

--- a/src/logs/log-buffer.ts
+++ b/src/logs/log-buffer.ts
@@ -21,8 +21,7 @@ export interface StepLogRecorder {
   attachAfter(allure: AllureRuntime, failed: boolean): void;
   attachAfterSuccess(allure: AllureRuntime): void;
   attachAfterFailure(allure: AllureRuntime): void;
-  resetPid(): void;
-  refreshPid(): void;
+  setPid(pid: number): void;
   close(): Promise<void>;
 }
 
@@ -57,13 +56,7 @@ export class LogBuffer implements StepLogRecorder {
     this._emitter.on('error', this._config.onError ?? noop);
   }
 
-  public resetPid() {
-    this._appEntries.pid = Number.NaN;
-    this._detoxEntries.pid = Number.NaN;
-  }
-
-  public refreshPid() {
-    const pid = this._config.device.getPid();
+  public setPid(pid: number) {
     this._appEntries.pid = pid;
     this._detoxEntries.pid = pid;
   }

--- a/src/steps/wrapWithSteps.ts
+++ b/src/steps/wrapWithSteps.ts
@@ -83,8 +83,6 @@ function initDescriptionMaker(platform: string): StepDescriptionMaker | undefine
   return undefined;
 }
 
-const PID_CHANGING_METHODS = new Set(['launchApp', 'relaunchApp', 'openURL']);
-
 function wrapDeviceMethod(
   { detox, allure, logs, screenshots }: WrapWithStepsOptions,
   methodName: string,
@@ -96,18 +94,9 @@ function wrapDeviceMethod(
 
   device[methodName] = async (...args: any[]) => {
     return await allure.step(stepDescription, async () => {
-      if (PID_CHANGING_METHODS.has(methodName)) {
-        logs?.resetPid();
-      }
-
       try {
         logs?.attachBefore(allure);
         const result = await originalMethod.apply(device, args);
-
-        if (PID_CHANGING_METHODS.has(methodName)) {
-          logs?.refreshPid();
-        }
-
         await screenshots?.attach(allure, false);
         logs?.attachAfterSuccess(allure);
 

--- a/src/utils/device-wrapper.ts
+++ b/src/utils/device-wrapper.ts
@@ -16,10 +16,4 @@ export class DeviceWrapper {
   get #deviceAny(): any {
     return this.device as any;
   }
-
-  getPid(bundleId?: string) {
-    const processes = this.#deviceAny._processes ?? {};
-    const key = bundleId ?? Object.keys(processes)[0];
-    return Number(processes[key]);
-  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,2 @@
-export * from './artifacts-wrapper';
 export * from './device-wrapper';
+export * from './worker-wrapper';

--- a/src/utils/worker-wrapper.ts
+++ b/src/utils/worker-wrapper.ts
@@ -1,8 +1,12 @@
-export class ArtifactsWrapper {
+export class WorkerWrapper {
   constructor(private readonly worker: any) {}
 
   get artifactsManager() {
     return this.worker._artifactsManager as ArtifactsManager;
+  }
+
+  get eventEmitter() {
+    return this.worker._eventEmitter as EventEmitter;
   }
 }
 
@@ -11,6 +15,12 @@ interface ArtifactsManager {
     log?: ArtifactPlugin;
   };
   on(event: string, callback: (...args: any[]) => void): void;
+}
+
+interface EventEmitter {
+  on(event: 'beforeLaunchApp', callback: () => void): void;
+  on(event: 'launchApp', callback: (event: { pid: number }) => void): void;
+  on(event: 'terminateApp', callback: () => void): void;
 }
 
 interface ArtifactPlugin {


### PR DESCRIPTION
* Use test_fn_* hooks for better positioning of attachments.
* Use detox emitter events to get app pid earlier (helpful for apps hanging up)