### PR TITLE
feat: density support in xml hierarchy

### DIFF
--- a/package-e2e/test.ts
+++ b/package-e2e/test.ts
@@ -6,6 +6,7 @@ import type {
   DetoxAllure2AdapterDeviceLogsOptions,
   DetoxAllure2AdapterDeviceScreenshotOptions,
   DetoxAllure2AdapterDeviceVideoOptions,
+  DetoxAllure2AdapterDeviceViewHierarchyOptions,
 } from 'detox-allure2-adapter';
 import DetoxAllurePathBuilder from 'detox-allure2-adapter/path-builder';
 import presetAllure from 'detox-allure2-adapter/preset-allure';
@@ -55,3 +56,5 @@ assertType<DetoxAllure2AdapterDeviceVideoOptions>({
     },
   },
 });
+
+assertType<DetoxAllure2AdapterDeviceViewHierarchyOptions>({});

--- a/scripts/generate-xsl.mjs
+++ b/scripts/generate-xsl.mjs
@@ -18,6 +18,7 @@ const iosXmlPath = join(templateDir, '__fixtures__', 'ios.xml');
 const iosPngPath = join(templateDir, '__fixtures__', 'ios.png');
 const androidXmlPath = join(templateDir, '__fixtures__', 'android.xml');
 const androidPngPath = join(templateDir, '__fixtures__', 'android.png');
+const errorXmlPath = join(templateDir, '__fixtures__', 'error.xml');
 
 // Output paths
 const outputPath = join(templateDir, 'index.ts');
@@ -25,6 +26,7 @@ const iosNoBgPath = join(templateDir, '__fixtures__', 'ios-no-bg.temp.xml');
 const iosBgPath = join(templateDir, '__fixtures__', 'ios-bg.temp.xml');
 const androidNoBgPath = join(templateDir, '__fixtures__', 'android-no-bg.temp.xml');
 const androidBgPath = join(templateDir, '__fixtures__', 'android-bg.temp.xml');
+const errorTempPath = join(templateDir, '__fixtures__', 'error.temp.xml');
 
 console.log('🔄 Generating XSL template...');
 
@@ -97,12 +99,22 @@ export default ${JSON.stringify(dataUrl)};
   generatePlatformFiles('iOS', iosXmlPath, iosPngPath, iosNoBgPath, iosBgPath);
   generatePlatformFiles('Android', androidXmlPath, androidPngPath, androidNoBgPath, androidBgPath);
 
+  // Generate error temp file (no background version needed)
+  console.log('🔄 Processing test error fixture...');
+  const errorXml = readFileSync(errorXmlPath, 'utf-8');
+  const errorTemp = errorXml.replace(
+    '\n',
+    `\n${xslPi}\n`
+  );
+  writeFileSync(errorTempPath, errorTemp, 'utf-8');
+
   console.log('✅ Generated XSL template successfully');
   console.log(`📁 Output: ${outputPath}`);
   console.log(`📁 iOS No-bg fixture: ${iosNoBgPath}`);
   console.log(`📁 iOS Bg fixture: ${iosBgPath}`);
   console.log(`📁 Android No-bg fixture: ${androidNoBgPath}`);
   console.log(`📁 Android Bg fixture: ${androidBgPath}`);
+  console.log(`📁 Error test fixture: ${errorTempPath}`);
   console.log(`📊 Size: ${Math.round(combinedTemplate.length / 1024)}KB`);
 
 } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type {
   DetoxAllure2AdapterDeviceLogsOptions,
   DetoxAllure2AdapterDeviceScreenshotOptions,
   DetoxAllure2AdapterDeviceVideoOptions,
+  DetoxAllure2AdapterDeviceViewHierarchyOptions,
 } from './types';
 
 export { listener as default } from './listener';

--- a/src/view-hierarchy/xsl/__fixtures__/android.xml
+++ b/src/view-hierarchy/xsl/__fixtures__/android.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF_8' standalone='yes' ?>
-<ViewHierarchy platform="android">
+<ViewHierarchy platform="android" density="2.625">
   <DecorView class="com.android.internal.policy.DecorView" width="1080" height="2400" visibility="visible" alpha="1.0" focused="false" x="0" y="0">
     <LinearLayout class="android.widget.LinearLayout" width="1080" height="2274" visibility="visible" alpha="1.0" focused="false" x="0" y="63">
       <ViewStub class="android.view.ViewStub" width="0" height="0" visibility="gone" alpha="1.0" focused="false" x="0" y="63" />

--- a/src/view-hierarchy/xsl/__fixtures__/error.xml
+++ b/src/view-hierarchy/xsl/__fixtures__/error.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF_8' standalone='yes' ?>
+<ViewHierarchy><ErrorMessage><![CDATA[Unknown error message which anyway should be displayed.]]></ErrorMessage></ViewHierarchy>

--- a/src/view-hierarchy/xsl/template.xsl
+++ b/src/view-hierarchy/xsl/template.xsl
@@ -5,6 +5,14 @@
   <xsl:variable name="activePtr" select="/ViewHierarchy/@active-ptr"/>
   <xsl:variable name="win" select="/ViewHierarchy/*[1]"/>
   <xsl:variable name="shot" select="/ViewHierarchy/@screenshot"/>
+  <xsl:variable name="density">
+    <xsl:choose>
+      <xsl:when test="/ViewHierarchy/@density">
+        <xsl:value-of select="/ViewHierarchy/@density"/>
+      </xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
 
   <xsl:output method="html" indent="yes" encoding="utf-8"/>
 
@@ -38,8 +46,8 @@
           </xsl:attribute>
 
           <xsl:attribute name="style">
-            <xsl:if test="$win/@width">width: <xsl:value-of select="$win/@width"/>px;</xsl:if>
-            <xsl:if test="$win/@height">height: <xsl:value-of select="$win/@height"/>px;</xsl:if>
+            <xsl:if test="$win/@width">width: <xsl:value-of select="$win/@width div $density"/>px;</xsl:if>
+            <xsl:if test="$win/@height">height: <xsl:value-of select="$win/@height div $density"/>px;</xsl:if>
             <xsl:if test="$shot != ''">
               background: url('<xsl:value-of select="$shot"/>') 0 0/contain no-repeat;
             </xsl:if>
@@ -84,16 +92,16 @@
         position: absolute;
         <xsl:choose>
           <xsl:when test="/ViewHierarchy/@platform = 'android'">
-            left: <xsl:value-of select="sum(@x) - sum(parent::*/@x)"/>px;
-            top: <xsl:value-of select="sum(@y) - sum(parent::*/@y)"/>px;
+            left: <xsl:value-of select="(sum(@x) - sum(parent::*/@x)) div $density"/>px;
+            top: <xsl:value-of select="(sum(@y) - sum(parent::*/@y)) div $density"/>px;
           </xsl:when>
           <xsl:otherwise>
-            left: <xsl:value-of select="@x"/>px;
-            top: <xsl:value-of select="@y"/>px;
+            left: <xsl:value-of select="@x div $density"/>px;
+            top: <xsl:value-of select="@y div $density"/>px;
           </xsl:otherwise>
         </xsl:choose>
-        width: <xsl:value-of select="@width"/>px;
-        height: <xsl:value-of select="@height"/>px;
+        width: <xsl:value-of select="@width div $density"/>px;
+        height: <xsl:value-of select="@height div $density"/>px;
         <xsl:if test="@alpha">opacity: <xsl:value-of select="@alpha"/>;</xsl:if>
       </xsl:attribute>
 


### PR DESCRIPTION
Fixes a problem with 1080x1920 files on Android, whereas the device have pixel density >1, and we should count take this into account. The resulting artifacts are much more convenient to browse.