### PR TITLE
fix(viewhierarchy): pollution by visibility screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ To use Detox, Jest, and Allure together, please verify that the following module
 ```json
 "devDependencies": {
   "detox": "^20.42.0",
-  "detox-allure2-adapter": "^1.0.0-alpha.35",
+  "detox-allure2-adapter": "^1.0.0-alpha.36",
   "jest": "^30.2.0",
-  "jest-allure2-reporter": "^2.2.7",
+  "jest-allure2-reporter": "^2.2.8",
   "jest-metadata": "^1.6.0"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "homepage": "https://github.com/wix-incubator/detox-allure2-adapter#readme",
   "peerDependencies": {
     "detox": ">=20.41.0",
-    "jest-allure2-reporter": "^2.2.7"
+    "jest-allure2-reporter": "^2.2.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
@@ -97,7 +97,7 @@
     "husky": "^8.0.3",
     "is-ci": "^3.0.1",
     "jest": "^29.6.2",
-    "jest-allure2-reporter": "^2.2.7",
+    "jest-allure2-reporter": "^2.2.8",
     "lint-staged": "^13.1.0",
     "lodash": "^4.17.21",
     "prettier": "^3.0.0",

--- a/src/steps/wrapWithSteps.ts
+++ b/src/steps/wrapWithSteps.ts
@@ -148,7 +148,7 @@ function wrapDeviceMethod(
       try {
         logs?.attachBefore(allure);
         const result = await originalMethod.apply(device, args);
-        await Promise.all([logs?.attachAfterSuccess(allure), screenshots?.attach(allure, false)]);
+        await Promise.all([logs?.attachAfterSuccess(allure), screenshots?.attachSuccess(allure)]);
 
         return result;
       } catch (error) {

--- a/src/view-hierarchy/screenshots-collector.ts
+++ b/src/view-hierarchy/screenshots-collector.ts
@@ -60,7 +60,7 @@ export class ScreenshotsCollector {
     await Promise.all(
       files.map((name) => {
         const screenshotPath = path.join(dirPath, name);
-        return allure.fileAttachment(screenshotPath, { handler: 'copy' });
+        return allure.fileAttachment(screenshotPath, { handler: 'move' });
       }),
     );
 


### PR DESCRIPTION
Fixes a problem with:

* untitled (image/png)
* untitled (image/png)
* untitled (image/png)
* untitled (image/png)

under each failed action.