### PR TITLE
fix(viewhierarchy): root directory in zip folders

### DIFF
--- a/src/file-handlers/zip-handler.ts
+++ b/src/file-handlers/zip-handler.ts
@@ -28,7 +28,7 @@ async function packDirectory(src: string): Promise<string> {
     output.on('end', () => resolve(dest));
 
     const archive = archiver('zip');
-    archive.directory(src, false);
+    archive.directory(src, path.basename(src));
     archive.pipe(output);
     archive.on('error', reject);
     archive.finalize();

--- a/src/steps/wrapWithSteps.ts
+++ b/src/steps/wrapWithSteps.ts
@@ -41,7 +41,6 @@ export function wrapWithSteps(options: WrapWithStepsOptions) {
   wrapDeviceMethod(options, 'launchApp', 'Launch app');
   wrapDeviceMethod(options, 'relaunchApp', 'Relaunch app');
   wrapDeviceMethod(options, 'openURL', 'Open URL');
-  wrapDeviceMethod(options, 'reloadReactNative', 'Reload React Native');
   wrapDeviceMethod(options, 'sendToHome', 'Send app to background');
   wrapDeviceMethod(options, 'setOrientation', 'Set orientation');
   wrapDeviceMethod(options, 'matchFace', 'Match face');


### PR DESCRIPTION
* Fixes a minor issue when unpacking `*.viewhierarchy.zip`. 
* Fixes nested "Reload React Native > Reload React Native" steps.