### PR TITLE
fix: videos on snapshot errors

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -200,7 +200,11 @@ export const listener: EnvironmentListenerFn = (
     .on('test_fn_success', async () => {
       await Promise.all([logs?.attachAfterSuccess(allure), screenshots?.attachSuccess(allure)]);
     })
-    .on('test_done', async () => {
+    .on('test_done', async ({ event }) => {
+      if (event.test.errors.length > 0) {
+        failing = true;
+      }
+
       await videoManager?.stopAndAttach($test, failing);
       $test = undefined;
     })


### PR DESCRIPTION
Not every failing test is actually failing — e.g. `toMatchSnapshot()` or some custom matchers may allow the test runner to continue, but the `.errors` array will be non-empty in `test_done`, hence, Jest deems such test result as FAIL. This fix exactly aligns us in this aspect.